### PR TITLE
Added option for endlabel generation on asm files

### DIFF
--- a/segtypes/n64/asm.py
+++ b/segtypes/n64/asm.py
@@ -27,7 +27,7 @@ class N64SegAsm(N64SegCodeSubsegment):
 
     def scan(self, rom_bytes: bytes):
         if self.rom_start != "auto" and self.rom_end != "auto" and self.rom_start != self.rom_end:
-            self.funcs_text = self.disassemble_code(rom_bytes, options.get("asm_endlabels"))
+            self.funcs_text = self.disassemble_code(rom_bytes, options.get("asm_endlabels", False))
 
     def split(self, rom_bytes: bytes):
         if not self.rom_start == self.rom_end:

--- a/segtypes/n64/asm.py
+++ b/segtypes/n64/asm.py
@@ -27,7 +27,7 @@ class N64SegAsm(N64SegCodeSubsegment):
 
     def scan(self, rom_bytes: bytes):
         if self.rom_start != "auto" and self.rom_end != "auto" and self.rom_start != self.rom_end:
-            self.funcs_text = self.disassemble_code(rom_bytes)
+            self.funcs_text = self.disassemble_code(rom_bytes, options.get("asm_endlabels"))
 
     def split(self, rom_bytes: bytes):
         if not self.rom_start == self.rom_end:

--- a/segtypes/n64/codesubsegment.py
+++ b/segtypes/n64/codesubsegment.py
@@ -39,7 +39,7 @@ class N64SegCodeSubsegment(Segment):
     def is_branch_insn(mnemonic):
         return (mnemonic.startswith("b") and not mnemonic.startswith("binsl") and not mnemonic == "break") or mnemonic == "j"
 
-    def disassemble_code(self, rom_bytes):
+    def disassemble_code(self, rom_bytes, addsuffix=False):
         insns = [insn for insn in N64SegCodeSubsegment.md.disasm(rom_bytes[self.rom_start : self.rom_end], self.vram_start)]
 
         funcs = self.process_insns(insns, self.rom_start)
@@ -50,7 +50,7 @@ class N64SegCodeSubsegment(Segment):
 
         funcs = self.determine_symbols(funcs)
         self.gather_jumptable_labels(rom_bytes)
-        return self.add_labels(funcs)
+        return self.add_labels(funcs, addsuffix)
 
     def process_insns(self, insns, rom_addr):
         assert(isinstance(self.parent, N64SegCode))
@@ -256,7 +256,7 @@ class N64SegCodeSubsegment(Segment):
             ret[func_addr] = func
         return ret
 
-    def add_labels(self, funcs):
+    def add_labels(self, funcs, addsuffix):
         ret = {}
 
         for func in funcs:
@@ -310,6 +310,9 @@ class N64SegCodeSubsegment(Segment):
 
                 if insn[0].mnemonic != "branch" and insn[0].mnemonic.startswith("b") or insn[0].mnemonic.startswith("j"):
                     indent_next = True
+            
+            if addsuffix:            
+                func_text.append(f"endlabel {sym.name}")
 
             ret[func] = (func_text, rom_addr)
 


### PR DESCRIPTION
This is a nice feature that allows for assembled objects to report function size correctly. If the option `asm_endlabels` is set, splat generates an `endlabel [label]` line at the end of every function in asm files.

This can be used in conjunction with macro.inc to add .ent and .end directives to asm files, which in turn ensures that `as` correctly saves the size of functions.

Doing this ensure `objdump -x` will show the correct size for asm functions (as opposed to zero without it) in the final linked elf, which is helpful for making more accurate progress scripts.