### PR TITLE
N64SegImg fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Image segment changes:
   * Added `flip_x` and `flip_y` boolean parameters to replace `flip`.
     * `flip` is deprecated and will produce a warning when used.
+    * Fixed flipping of `ci4` and `ci8` images.
   * Fixed `extract: false` (and `start: auto`) behaviour.
 
 ## 0.7.0: The Path Update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # splat Release Notes
 
-## 0.7.1
+### 0.7.1
 
 * Image segment changes:
   * Added `flip_x` and `flip_y` boolean parameters to replace `flip`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # splat Release Notes
 
-## unreleased
+## 0.7.1
 
 * Image segment changes:
-  * BREAKING: Replaced the `flip` parameter with separated `flip_x` and `flip_y` boolean parameters.
+  * Added `flip_x` and `flip_y` boolean parameters to replace `flip`.
+    * `flip` is deprecated and will produce a warning when used.
   * Fixed `extract: false` (and `start: auto`) behaviour.
 
-## 0.7: The Path Update
+## 0.7.0: The Path Update
 
 * Significantly better performance, especially when using the cache feature (`--use-cache` CLI arg).
 * BREAKING: Some cli args for splat have been renamed. Please consult the usage output (-h or no args) for more information.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # splat Release Notes
 
+## unreleased
+
+* Image segment changes:
+  * BREAKING: Replaced the `flip` parameter with separated `flip_x` and `flip_y` boolean parameters.
+  * Fixed `extract: false` (and `start: auto`) behaviour.
+
 ## 0.7: The Path Update
 
 * Significantly better performance, especially when using the cache feature (`--use-cache` CLI arg).

--- a/segtypes/linker_entry.py
+++ b/segtypes/linker_entry.py
@@ -78,8 +78,9 @@ class LinkerWriter():
                 if start % 0x10 != 0 and i != 0:
                     do_next = True
 
-            path_cname = re.sub(r"[^0-9a-zA-Z_]", "_", str(entry.segment.dir / entry.segment.name) + ".".join(entry.object_path.suffixes[:-1]))
-            self._write_symbol(path_cname, ".")
+            if entry.object_path:
+                path_cname = re.sub(r"[^0-9a-zA-Z_]", "_", str(entry.segment.dir / entry.segment.name) + ".".join(entry.object_path.suffixes[:-1]))
+                self._write_symbol(path_cname, ".")
 
             if entry.section != "linker":
                 self._writeln(f"{entry.object_path}({entry.section});")

--- a/segtypes/n64/ci4.py
+++ b/segtypes/n64/ci4.py
@@ -1,11 +1,12 @@
 from segtypes.n64.ci8 import N64SegCi8
+from util import iter
 
 class N64SegCi4(N64SegCi8):
     @staticmethod
     def parse_image(data, width, height, flip_h=False, flip_v=False):
         img_data = bytearray()
 
-        for i in range(width * height // 2):
+        for x, y, i in iter.iter_image_indexes(width, height, 0.5, 1, flip_h, flip_v):
             img_data.append(data[i] >> 4)
             img_data.append(data[i] & 0xF)
 

--- a/segtypes/n64/ci8.py
+++ b/segtypes/n64/ci8.py
@@ -3,6 +3,7 @@ from segtypes.n64.rgba16 import N64SegRgba16
 import png
 from util import log
 from util import options
+from util import iter
 
 if TYPE_CHECKING:
     from segtypes.n64.palette import N64SegPalette as Palette
@@ -35,7 +36,19 @@ class N64SegCi8(N64SegRgba16):
 
     @staticmethod
     def parse_image(data, width, height, flip_h=False, flip_v=False):
-        return data
+        # hot path
+        if not flip_h and not flip_v:
+            return data
+        
+        flipped_data = bytearray()
+
+        for x, y, i in iter.iter_image_indexes(width, height, 1, 1, flip_h, flip_v):
+            flipped_data.append(data[i])
+
+        return flipped_data
 
     def max_length(self):
         return self.width * self.height
+
+    def cache(self):
+        return (self.config, self.rom_end, 1)

--- a/segtypes/n64/group.py
+++ b/segtypes/n64/group.py
@@ -57,6 +57,7 @@ class N64SegGroup(N64Segment):
             segment.parent = self
             
             if segment.rom_start != "auto":
+                assert isinstance(segment.rom_start, int)
                 segment.vram_start = self.rom_to_ram(segment.rom_start)
 
             # TODO: assumes section order - generalize and stuff

--- a/segtypes/n64/img.py
+++ b/segtypes/n64/img.py
@@ -17,11 +17,15 @@ class N64SegImg(N64Segment):
             self.flip_vertical = bool(segment.get("flip_y", False))
 
             if segment.get("flip"):
-                log.error(f"Error: {self.name}: 'flip' parameter has been removed; use flip_x and flip_y instead")
+                self.warn(f"'flip' parameter for img segments is deprecated; use flip_x and flip_y instead")
+                flip = segment.get("flip")
+
+                self.flip_vertical = flip == "both" or flip.startswith("v") or flip == "y"
+                self.flip_horizontal = flip == "both" or flip.startswith("h") or flip == "x"
         else:
             if self.extract:
                 if len(segment) < 5:
-                    log.error("missing parameters")
+                    log.error(f"Error: {self.name} is missing width and height parameters")
                 self.width = segment[3]
                 self.height = segment[4]
 

--- a/segtypes/n64/img.py
+++ b/segtypes/n64/img.py
@@ -2,10 +2,43 @@ from pathlib import Path
 from typing import Optional
 from segtypes.n64.segment import N64Segment
 from util import options
+from util import log
 
 class N64SegImg(N64Segment):
+    def __init__(self, segment, rom_start, rom_end):
+        super().__init__(segment, rom_start, rom_end)
+
+        if type(segment) is dict:
+            if self.extract:
+                self.width = segment["width"]
+                self.height = segment["height"]
+
+            self.flip_horizontal = bool(segment.get("flip_x", False))
+            self.flip_vertical = bool(segment.get("flip_y", False))
+
+            if segment.get("flip"):
+                log.error(f"Error: {self.name}: 'flip' parameter has been removed; use flip_x and flip_y instead")
+        else:
+            if self.extract:
+                if len(segment) < 5:
+                    log.error("missing parameters")
+                self.width = segment[3]
+                self.height = segment[4]
+
+            self.flip_horizontal = False
+            self.flip_vertical = False
+
+        if self.extract and self.max_length() is not None:
+            expected_len = int(self.max_length())
+            actual_len = self.rom_end - self.rom_start
+            if actual_len > expected_len and actual_len - expected_len > self.subalign:
+                log.error(f"Error: {self.name} should end at 0x{self.rom_start + expected_len:X}, but it ends at 0x{self.rom_end:X}\n(hint: add a 'bin' segment after it)")
+
     def out_path(self) -> Optional[Path]:
         return options.get_asset_path() / self.dir / f"{self.name}.png"
 
     def should_split(self) -> bool:
         return self.extract and options.mode_active("img")
+
+    def max_length(self) -> Optional[int]:
+        return None

--- a/segtypes/n64/palette.py
+++ b/segtypes/n64/palette.py
@@ -27,18 +27,19 @@ class N64SegPalette(N64Segment):
             self.name.split(".")[0]
         ) if type(segment) is dict else self.name.split(".")[0]
 
-        if self.rom_end == "auto":
-            log.error(f"segment {self.name} needs to know where it ends; add a position marker [0xDEADBEEF] after it")
+        if self.extract:
+            if self.rom_end == "auto":
+                log.error(f"segment {self.name} needs to know where it ends; add a position marker [0xDEADBEEF] after it")
 
-        if self.max_length() and isinstance(self.rom_end, int):
-            expected_len = int(self.max_length())
-            actual_len = self.rom_end - self.rom_start
-            if actual_len > expected_len and actual_len - expected_len > self.subalign:
-                log.error(f"Error: {self.name} should end at 0x{self.rom_start + expected_len:X}, but it ends at 0x{self.rom_end:X}\n(hint: add a 'bin' segment after it)")
+            if self.max_length() and isinstance(self.rom_end, int):
+                expected_len = int(self.max_length())
+                actual_len = self.rom_end - self.rom_start
+                if actual_len > expected_len and actual_len - expected_len > self.subalign:
+                    log.error(f"Error: {self.name} should end at 0x{self.rom_start + expected_len:X}, but it ends at 0x{self.rom_end:X}\n(hint: add a 'bin' segment after it)")
 
     def should_split(self):
-        return super().should_split() or options.mode_active("img")
-    
+        return self.extract and (super().should_split() or options.mode_active("img"))
+ 
     def out_path(self) -> Optional[Path]:
         return options.get_asset_path() / self.dir / f"{self.name}.png"
 

--- a/segtypes/n64/rgba16.py
+++ b/segtypes/n64/rgba16.py
@@ -7,37 +7,6 @@ from util.color import unpack_color
 
 # TODO: move common behaviour to N64ImgSegment and have all image segments extend that instead
 class N64SegRgba16(N64SegImg):
-    def __init__(self, segment, rom_start, rom_end):
-        super().__init__(segment, rom_start, rom_end)
-
-        if type(segment) is dict:
-            self.width = segment["width"]
-            self.height = segment["height"]
-            self.flip = segment.get("flip", "noflip")
-        elif len(segment) < 5:
-            log.error("missing parameters")
-        else:
-            self.width = segment[3]
-            self.height = segment[4]
-            self.flip = "noflip"
-
-        if self.max_length():
-            expected_len = int(self.max_length())
-            actual_len = self.rom_end - self.rom_start
-            if actual_len > expected_len and actual_len - expected_len > self.subalign:
-                log.error(f"Error: {self.name} should end at 0x{self.rom_start + expected_len:X}, but it ends at 0x{self.rom_end:X}\n(hint: add a 'bin' segment after it)")
-
-    @property
-    def flip_vertical(self):
-        return self.flip == "both" or self.flip.startswith("v") or self.flip == "y"
-
-    @property
-    def flip_horizontal(self):
-        return self.flip == "both" or self.flip.startswith("h") or self.flip == "x"
-
-    def should_split(self):
-        return super().should_split() or options.mode_active("img")
-
     def split(self, rom_bytes):
         path = self.out_path()
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/segtypes/segment.py
+++ b/segtypes/segment.py
@@ -1,5 +1,5 @@
 import importlib
-from typing import Dict, TYPE_CHECKING, Union, Optional, List, Literal
+from typing import Dict, TYPE_CHECKING, Union, Optional, List
 from pathlib import Path
 from util import log
 from util import options
@@ -10,7 +10,7 @@ import sys
 if TYPE_CHECKING:
     from segtypes.linker_entry import LinkerEntry
 
-RomAddr = Union[int, Literal["auto"]]
+RomAddr = Union[int, str]
 
 
 def parse_segment_vram(segment: Union[dict, list]) -> Optional[int]:

--- a/util/iter.py
+++ b/util/iter.py
@@ -6,12 +6,12 @@ def iter_in_groups(iterable, n, fillvalue=None):
     return zip_longest(*args, fillvalue=fillvalue)
 
 def iter_image_indexes(width, height, bytes_per_x=1, bytes_per_y=1, flip_h=False, flip_v=False):
-        w = int(width * bytes_per_x)
-        h = int(height * bytes_per_y)
+    w = int(width * bytes_per_x)
+    h = int(height * bytes_per_y)
 
-        xrange = range(w - ceil(bytes_per_x), -1, -ceil(bytes_per_x)) if flip_h else range(0, w, ceil(bytes_per_x))
-        yrange = range(h - ceil(bytes_per_y), -1, -ceil(bytes_per_y)) if flip_v else range(0, h, ceil(bytes_per_y))
+    xrange = range(w - ceil(bytes_per_x), -1, -ceil(bytes_per_x)) if flip_h else range(0, w, ceil(bytes_per_x))
+    yrange = range(h - ceil(bytes_per_y), -1, -ceil(bytes_per_y)) if flip_v else range(0, h, ceil(bytes_per_y))
 
-        for y in yrange:
-            for x in xrange:
-                yield x, y, (y * w) + x
+    for y in yrange:
+        for x in xrange:
+            yield x, y, (y * w) + x

--- a/util/log.py
+++ b/util/log.py
@@ -1,12 +1,12 @@
 import sys
 from colorama import init, Fore, Style
-from typing import Union, Literal
+from typing import Optional
 
 init(autoreset=True)
 
 newline = True
 
-Status = Union[None, Literal["ok"], Literal["warn"], Literal["error"], Literal["skip"]]
+Status = Optional[str]
 
 def write(*args, status=None, **kwargs):
     global newline


### PR DESCRIPTION
* Image segment changes:
  * Added `flip_x` and `flip_y` boolean parameters to replace `flip`.
    * `flip` is deprecated and will produce a warning when used.
    * Fixed flipping of `ci4` and `ci8` images.
  * Fixed `extract: false` (and `start: auto`) behaviour.
