### PR TITLE
Updating 'options' section for create_config.py

### DIFF
--- a/create_config.py
+++ b/create_config.py
@@ -1,35 +1,44 @@
 #! /usr/bin/env python3
 
 import argparse
-from util.n64 import rominfo
-from util.n64 import find_code_length
+from util.n64 import rominfo, find_code_length
 
-parser = argparse.ArgumentParser(description="Create a splat config from a rom (currently only n64 .z64 roms supported)")
-parser.add_argument("rom", help="path to a .z64 rom")
+parser = argparse.ArgumentParser(description="Create a splat config from a ROM. "
+                                             "Only n64 .z64 ROMs are supported")
+parser.add_argument("rom", help="Path to a .z64 ROM")
 
 
 def main(rom_path):
     rom = rominfo.get_info(rom_path)
     basename = rom.name.replace(" ", "").lower()
 
-    header = \
-"""name: {0} ({1})
-basename: {2}
+    header = f"""
+name: {rom.name.title()} ({rom.get_country_name()})
 options:
-  find_file_boundaries: True
-  compiler: IDO
-  platform: n64
+  basename: {basename}
+  target_path: {rom_path}
   base_path: .
-  target_path: baserom.z64
-""".format(rom.name.title(), rom.get_country_name(), basename)
+  compiler: {rom.compiler}
+  find_file_boundaries: True
+  # platform: n64
+  # undefined_funcs_auto_path: undefined_funcs_auto.txt
+  # undefined_syms_auto_path: undefined_syms_auto.txt
+  # symbol_addrs_path: symbol_addrs.txt
+  # undefined_syms_path: undefined_syms.txt
+  # asm_path: asm
+  # src_path: src
+  # build_path: build
+  # extensions_path: tools/splat_ext
+  # section_order: [.text, .data, .rodata, .bss]
+""".lstrip()
 
     with open(rom_path, "rb") as f:
-      fbytes = f.read()
+        fbytes = f.read()
 
     first_section_end = find_code_length.run(fbytes, 0x1000, rom.entry_point)
 
-    segments = \
-"""segments:
+    segments = f"""
+segments:
   - name: header
     type: header
     start: 0x0
@@ -39,19 +48,17 @@ options:
   - name: main
     type: code
     start: 0x1000
-    vram: 0x{:X}
+    vram: 0x{rom.entry_point:X}
     subsegments:
       - [0x1000, asm]
   - type: bin
-    start: 0x{:X}
-  - [0x{:X}]
-""".format(rom.entry_point, first_section_end, rom.size)
+    start: 0x{first_section_end:X}
+  - [0x{rom.size:X}]
+""".lstrip()
 
-    outstr = header + segments
+    with open(basename + ".yaml", "w", newline="\n") as f:
+        f.write(header + segments)
 
-    outname = rom.name.replace(" ", "").lower()
-    with open(outname + ".yaml", "w", newline="\n") as f:
-        f.write(outstr)
 
 if __name__ == "__main__":
     args = parser.parse_args()

--- a/util/n64/rominfo.py
+++ b/util/n64/rominfo.py
@@ -90,11 +90,13 @@ def get_info_bytes(rom_bytes, encoding):
     #     if rom_bytes.find(bytes(format, "ASCII")) != -1:
     #         compression_formats.append(format)
 
-    return N64Rom(name, country_code, libultra_version, crc1, crc2, cic, entry_point, len(rom_bytes))
+    compiler = get_compiler_info(rom_bytes, entry_point, print_result=False)
+
+    return N64Rom(name, country_code, libultra_version, crc1, crc2, cic, entry_point, len(rom_bytes), compiler)
 
 
 class N64Rom:
-    def __init__(self, name, country_code, libultra_version, crc1, crc2, cic, entry_point, size):
+    def __init__(self, name, country_code, libultra_version, crc1, crc2, cic, entry_point, size, compiler):
         self.name = name
         self.country_code = country_code
         self.libultra_version = libultra_version
@@ -103,11 +105,12 @@ class N64Rom:
         self.cic = cic
         self.entry_point = entry_point
         self.size = size
+        self.compiler = compiler
 
     def get_country_name(self):
         return country_codes[self.country_code]
 
-def get_compiler_info(rom_bytes, entry_point):
+def get_compiler_info(rom_bytes, entry_point, print_result=True):
     md = Cs(CS_ARCH_MIPS, CS_MODE_MIPS64 + CS_MODE_BIG_ENDIAN)
     md.detail = True
 
@@ -121,8 +124,9 @@ def get_compiler_info(rom_bytes, entry_point):
             branches += 1
 
     compiler = "IDO" if branches > jumps else "GCC"
-
-    print(f"{branches} branches and {jumps} jumps detected in the first code segment. Compiler is most likely {compiler}")
+    if (print_result):
+        print(f"{branches} branches and {jumps} jumps detected in the first code segment. Compiler is most likely {compiler}")
+    return compiler
 
 # TODO: support .n64 extension
 def main():


### PR DESCRIPTION
- minor 'bugfix'  putting `basename` inside `options` to prevent basename defaulting to `None`
- adding compiler (based on logic in rom_info)
- adding other `options` (with defaults + commented out) for reference
- switched to `f"{var}"` style as this is already used in rom_info (Python 3.6+)
- couple of formatting tweaks