### PR TITLE
add linker_offset segtype

### DIFF
--- a/segtypes/linker_entry.py
+++ b/segtypes/linker_entry.py
@@ -42,7 +42,7 @@ class LinkerEntry:
         self.segment = segment
         self.src_paths = [clean_up_path(p) for p in src_paths]
         self.section = section
-        if self.section == "linker":
+        if self.section == "linker" or self.section == "linker_offset":
             self.object_path = None
         else:
             self.object_path = path_to_object_path(object_path)
@@ -83,6 +83,9 @@ class LinkerWriter():
             if cur_section == "linker": # TODO: isinstance is preferable
                 self._end_block()
                 self._begin_segment(entry.segment)
+                continue
+            elif cur_section == "linker_offset":
+                self._write_symbol(f"{get_segment_cname(entry.segment)}_OFFSET", f". - {get_segment_cname(segment)}_ROM_START")
                 continue
 
             # text/data/bss START/END labels

--- a/segtypes/n64/linker_offset.py
+++ b/segtypes/n64/linker_offset.py
@@ -1,0 +1,8 @@
+from segtypes.n64.segment import N64Segment
+
+class N64SegLinker_offset(N64Segment):
+    def get_linker_entries(self):
+        from segtypes.linker_entry import LinkerEntry
+
+        return [LinkerEntry(self, [], self.name, "linker_offset")]
+


### PR DESCRIPTION
`[_, linker_offset, name]` generates a linker symbol `name_OFFSET = . - parent_ROM_START` at its position in the linker script.

For example:
```yaml
  - type: group
    dir: charset
    start: 0x10F1B0
    subsegments:
    - [0x10F1B0, linker_offset,       standard]
    - [0x10F1B0, pm_charset,          standard, 16, 16, 0xA6]
    - [0x1144B0, linker_offset,       standard_pal]
    - [0x1144B0, pm_charset_palettes, standard,         0x50]
    - [0x1149B0, linker_offset,       title]
    - [0x1149B0, pm_charset,          title,    12, 15, 0x29]
    - [0x115910, linker_offset,       subtitle]
    - [0x115910, pm_charset,          subtitle, 12, 12, 0x29]
    - [0x116498, linker_offset,       credits_pal]
```
Results in the linker section:
```
    charset_ROM_START = __romPos;
    charset_VRAM = ADDR(.charset);
    .charset : AT(charset_ROM_START) SUBALIGN(8)
    {
        charset_TEXT_START = .;
        charset_standard_OFFSET = . - charset_ROM_START;
        charset_TEXT_END = .;
        charset_DATA_START = .;
        charset_standard_dat = .;
        ver/us/build/assets/us/charset/standard.dat.o(.data);
        charset_standard_pal_OFFSET = . - charset_ROM_START;
        charset_standard_dat = .;
        ver/us/build/assets/us/charset/standard/palette.dat.o(.data);
        charset_title_OFFSET = . - charset_ROM_START;
        charset_title_dat = .;
        ver/us/build/assets/us/charset/title.dat.o(.data);
        charset_subtitle_OFFSET = . - charset_ROM_START;
        charset_subtitle_dat = .;
        ver/us/build/assets/us/charset/subtitle.dat.o(.data);
        charset_credits_pal_OFFSET = . - charset_ROM_START;
    }
```

This allows us to [match functions like `load_font` in papermario's `msg.c`](https://github.com/pmret/papermario/commit/92d3161f8a3dcdeea843b436306378b3ca8582c6):
```c
void load_font(s32 font) {
    if (font != D_80155C98) {
        if (font == 0) {
            load_font_data(charset_standard_OFFSET, 0x5100, &D_802EE8D0); // charset_standard_OFFSET = 0
            load_font_data(charset_standard_pal_OFFSET, 0x500, &D_802F4560); // charset_standard_pal_OFFSET = 0x5300
        } else if (font == 1) {
            load_font_data(charset_title_OFFSET, 0xF60, &D_802ED970);
            load_font_data(charset_subtitle_OFFSET, 0xB88, &D_802F39D0);
            load_font_data(charset_credits_pal_OFFSET, 0x80, &D_802F4560);
        }
    }
}
```