### PR TITLE
Ignore #pragma GLOBAL_ASM and similar when parsing defined functions

### DIFF
--- a/segtypes/n64/c.py
+++ b/segtypes/n64/c.py
@@ -17,7 +17,7 @@ class N64SegC(N64SegCodeSubsegment):
     )
 
     C_FUNC_RE = re.compile(
-        r"^(static\s+)?[^\s]+\s+([^\s(]+)\(([^;)]*)\)[^;]+?{",
+        r"^(static\s+)?[^#\s]+\s+\**([^\s(]+)\(([^;)]*)\)[^;]+?{",
         re.MULTILINE
     )
 


### PR DESCRIPTION
Test cases:
```c
void func_802C7BB4_6D9264(u16 arg0) {
    D_803D5528->unk37A = D_803D5528->unk374;
    D_803D5528->unk37C = D_803D5528->unk376;
}

#pragma GLOBAL_ASM("asm/nonmatchings/overlay2_6D6120/func_802C7A7C_6D912C.s")
void func_802C7B18_6D91C8(struct061 *arg0, s16 arg1) {
    s16 temp_v0;
    s16 temp_v1;

    temp_v0 = arg0->unk0;
    temp_v1 = arg0->unk2;
}


void *func_80130BA0(void) {
    s16 i;
    for (i = 0; i < 60U; i++) {
        // debug stuff removed?
    };
    return NULL;
}

void* func_80130DA0(void) {
    s16 i;
    for (i = 0; i < 60U; i++) {
        // debug stuff removed?
    };
    return NULL;
}

#ifdef NON_MATCHING
void func_802C5EF4_6D75A4(s16 arg0, s16 arg1) {
    D_80203FE0[19].unk0 = D_80203FE0[1].unk0;
    D_80203FE0[19].unk2 = D_80203FE0[1].unk2;
    D_80203FE0[19].unk4 = D_80203FE0[1].unk4 + arg0;

    D_80203FE0[20].unk0 = D_80203FE0[1].unk0;
    D_80203FE0[20].unk2 = D_80203FE0[1].unk2 + arg1;
    D_80203FE0[20].unk4 = D_80203FE0[1].unk4 + arg0;

}
#else
#pragma GLOBAL_ASM("asm/nonmatchings/overlay2_6D6120/func_802C5EF4_6D75A4.s")
#endif

static s32 foo(s32 arg0) {
    return 1;
}
```