### PR TITLE
Allow for not discarding all elf sections and generate a list of sections

### DIFF
--- a/segtypes/linker_entry.py
+++ b/segtypes/linker_entry.py
@@ -66,7 +66,7 @@ class LinkerEntry:
 class LinkerWriter():
     def __init__(self):
         self.shiftable: bool = options.get("shiftable", False)
-        self.ignore_discard: bool = options.get("ignore_discard", False)
+        self.linker_discard_section: bool = options.get("linker_discard_section", True)
         self.entries: List[LinkerEntry] = []
 
         self.buffer: List[str] = []
@@ -155,7 +155,7 @@ class LinkerWriter():
         self._end_segment(segment)
 
     def save_linker_script(self):
-        if not self.ignore_discard:
+        if self.linker_discard_section:
             self._writeln("/DISCARD/ :")
             self._begin_block()
             self._writeln("*(*);")

--- a/split.py
+++ b/split.py
@@ -236,13 +236,14 @@ def main(config_path, base_dir, target_path, modes, verbose, use_cache=True):
         linker_writer.save_linker_script()
         linker_writer.save_symbol_header()
 
-        # write objcopy_sections.txt
-        if options.get_create_objcopy_section_auto():
-            objcopy_data = ""
+        # write elf_sections.txt - this only lists the generated sections in the elf, not sub sections
+        # that the elf combines into one section
+        if options.get_create_elf_section_list_auto():
+            section_list = ""
             for segment in all_segments:
-                objcopy_data += " -j ." + to_cname(segment.name)
-            with open(options.get_objcopy_section_path(), "w", newline="\n") as f:
-                f.write(objcopy_data)
+                section_list += "." + to_cname(segment.name) + "\n"
+            with open(options.get_elf_section_list_path(), "w", newline="\n") as f:
+                f.write(section_list)
 
     # Write undefined_funcs_auto.txt
     if options.get_create_undefined_funcs_auto():

--- a/util/options.py
+++ b/util/options.py
@@ -77,11 +77,11 @@ def get_create_undefined_syms_auto() -> bool:
 def get_undefined_syms_auto_path():
     return get_base_path() / opts.get("undefined_syms_auto_path", "undefined_syms_auto.txt")
 
-def get_create_objcopy_section_auto():
-    return opts.get("create_objcopy_section_auto", False)
+def get_create_elf_section_list_auto():
+    return opts.get("create_elf_section_list_auto", False)
 
-def get_objcopy_section_path():
-    return get_base_path() / opts.get("objcopy_section_path", "objcopy_sections.txt")
+def get_elf_section_list_path():
+    return get_base_path() / opts.get("elf_section_list_path", "elf_sections.txt")
 
 def get_symbol_addrs_path():
     return get_base_path() / opts.get("symbol_addrs_path", "symbol_addrs.txt")


### PR DESCRIPTION
Add code to allow bypassing the discard entry in the linker script and to generate a list of sections for objcopy if desired