### PR TITLE
Add "generated_s_preamble" option

### DIFF
--- a/segtypes/n64/asm.py
+++ b/segtypes/n64/asm.py
@@ -18,7 +18,7 @@ class N64SegAsm(CommonSegAsm):
         ret.append(".set gp=64     # allow use of 64-bit general purpose registers")
         ret.append("")
         preamble = options.get_generated_s_preamble()
-        if (preamble != ""):
+        if preamble:
             ret.append(preamble)
             ret.append("")
         ret.append(".section .text, \"ax\"")

--- a/segtypes/n64/asm.py
+++ b/segtypes/n64/asm.py
@@ -17,6 +17,10 @@ class N64SegAsm(CommonSegAsm):
         ret.append(".set noreorder # don't insert nops after branches")
         ret.append(".set gp=64     # allow use of 64-bit general purpose registers")
         ret.append("")
+        preamble = options.get_generated_s_preamble()
+        if (preamble != ""):
+            ret.append(preamble)
+            ret.append("")
         ret.append(".section .text, \"ax\"")
         ret.append("")
 

--- a/segtypes/psx/asm.py
+++ b/segtypes/psx/asm.py
@@ -17,7 +17,7 @@ class PsxSegAsm(CommonSegAsm):
         ret.append(".set noreorder # don't insert nops after branches")
         ret.append("")
         preamble = options.get_generated_s_preamble()
-        if (preamble != ""):
+        if preamble:
             ret.append(preamble)
             ret.append("")
         ret.append(".section .text, \"ax\"")

--- a/segtypes/psx/asm.py
+++ b/segtypes/psx/asm.py
@@ -16,6 +16,10 @@ class PsxSegAsm(CommonSegAsm):
         ret.append(".set noat      # allow manual use of $at")
         ret.append(".set noreorder # don't insert nops after branches")
         ret.append("")
+        preamble = options.get_generated_s_preamble()
+        if (preamble != ""):
+            ret.append(preamble)
+            ret.append("")
         ret.append(".section .text, \"ax\"")
         ret.append("")
 

--- a/util/options.py
+++ b/util/options.py
@@ -44,6 +44,9 @@ def get_subalign() -> int:
 def get_generated_c_premble() -> str:
     return opts.get("generated_c_preamble", '#include "common.h"')
 
+def get_generated_s_preamble() -> str:
+    return opts.get("generated_s_preamble")
+
 def mode_active(mode):
     return mode in opts["modes"] or "all" in opts["modes"]
 

--- a/util/options.py
+++ b/util/options.py
@@ -45,7 +45,7 @@ def get_generated_c_premble() -> str:
     return opts.get("generated_c_preamble", '#include "common.h"')
 
 def get_generated_s_preamble() -> str:
-    return opts.get("generated_s_preamble")
+    return opts.get("generated_s_preamble", "")
 
 def mode_active(mode):
     return mode in opts["modes"] or "all" in opts["modes"]


### PR DESCRIPTION
I added the option to append onto the existing assembly preamble. You can see it being used here to suppress compiler warnings about odd-fp regs: https://github.com/Drahsid/turok3/blob/bfc9a8b88f147f5cc1b856a7146c7b611bde30ee/turok3.yaml#L11