### PR TITLE
simplify BSS_START logic

### DIFF
--- a/segtypes/linker_entry.py
+++ b/segtypes/linker_entry.py
@@ -117,10 +117,7 @@ class LinkerWriter():
                 data_ended = True
                 self._write_symbol(f"{seg_name}_DATA_END", ".")
 
-                if not bss_started and i < (len(entries) - 1) and "bss" in entries[i + 1].section:
-                    bss_started = True
-                    self._write_symbol(f"{seg_name}_BSS_START", ".")
-            elif not bss_started and "bss" in cur_section:
+            if data_ended and not bss_started and "bss" in cur_section:
                 bss_started = True
                 self._write_symbol(f"{seg_name}_BSS_START", ".")
 

--- a/util/options.py
+++ b/util/options.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union, Literal
 from pathlib import Path
 from util import log
 
@@ -29,7 +29,7 @@ def get(opt, default=None):
 def get_platform() -> str:
     return opts.get("platform", "n64")
 
-def get_endianess() -> str:
+def get_endianess() -> Union[Literal["little"], Literal["big"]]:
     return opts.get("endianess", "little" if get_platform().upper() == "PSX" else "big")
 
 def get_compiler() -> str:


### PR DESCRIPTION
Seems to be an bug if there is only one `.bss` segment and its the final segment (which it would be), if there are multiple `.bss` segments the bug doesnt present itself. Hopefully this change doesnt break pmret.

before:
```
        overlay2_DATA_END = .;
        build/src.us/overlay2_6A6500.c.o(.bss);
        overlay2_BSS_START = .;
        overlay2_BSS_END = .;
```
after:
```
        overlay1_DATA_END = .;
        overlay1_BSS_START = .;
        build/src.us/overlay1_6384F0.c.o(.bss);
        overlay1_BSS_END = .;
```

although I guess it doesnt *actually* harm anything as the start is the same.. just looks wrong