### PR TITLE
Added 'use_function_labels' option, which emits func instead of glabel for functions when enabled

### DIFF
--- a/segtypes/common/codesubsegment.py
+++ b/segtypes/common/codesubsegment.py
@@ -280,6 +280,8 @@ class CommonSegCodeSubsegment(Segment):
 
     def add_labels(self, funcs, addsuffix):
         ret = {}
+        
+        use_function_labels = options.get("use_function_labels", False)
 
         for func in funcs:
             func_text = []
@@ -287,7 +289,10 @@ class CommonSegCodeSubsegment(Segment):
             # Add function glabel
             rom_addr = funcs[func][0][3]
             sym = self.parent.get_symbol(func, type="func", create=True, define=True, local_only=True)
-            func_text.append(f"glabel {sym.name}")
+            if use_function_labels:
+                func_text.append(f"func {sym.name}")
+            else:
+                func_text.append(f"glabel {sym.name}")
 
             indent_next = False
 

--- a/segtypes/common/codesubsegment.py
+++ b/segtypes/common/codesubsegment.py
@@ -281,7 +281,7 @@ class CommonSegCodeSubsegment(Segment):
     def add_labels(self, funcs, addsuffix):
         ret = {}
         
-        use_function_labels = options.get("use_function_labels", False)
+        function_macro = options.get_asm_function_macro()
 
         for func in funcs:
             func_text = []
@@ -289,10 +289,7 @@ class CommonSegCodeSubsegment(Segment):
             # Add function glabel
             rom_addr = funcs[func][0][3]
             sym = self.parent.get_symbol(func, type="func", create=True, define=True, local_only=True)
-            if use_function_labels:
-                func_text.append(f"func {sym.name}")
-            else:
-                func_text.append(f"glabel {sym.name}")
+            func_text.append(f"{function_macro} {sym.name}")
 
             indent_next = False
 

--- a/util/options.py
+++ b/util/options.py
@@ -117,3 +117,6 @@ def get_lib_path() -> Path:
 
 def get_migrate_rodata_to_functions() -> bool:
     return opts.get("migrate_rodata_to_functions", True)
+
+def get_asm_function_macro() -> str:
+    return opts.get("asm_function_macro", "glabel")


### PR DESCRIPTION
This is useful along with the previously added `asm_endlabels` for preventing assembler warnings caused by .ent appearing outside of .text sections, as the .ent directive can just be added to the function label macro instead of glabel itself.