### PR TITLE
Improvements to rominfo.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ venv/
 __pycache__/
 .mypy_cache/
 util/n64/Yay0decompress
+*.ld
+*.n64
+*.yaml
+*.z64

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # splat
 A binary splitting tool to assist with decompilation and modding projects
 
-Currently, only N64(.z64) and PSX binaries are supported.
+Currently, only N64 and PSX binaries are supported.
 
-For example usage, see https://github.com/pmret/papermario
-The Makefile `setup` target calls splat with a config file that you can use for reference. More documentation coming soon.
+The Makefile `setup` target calls splat with a config file that you can use for reference.
+
+Please check out the [wiki](https://github.com/ethteck/splat/wiki) for more information including [examples](https://github.com/ethteck/splat/wiki/Examples) of projects that use splat.
 
 ### Requirements
 Python package requirements can be installed via `pip3 install -r requirements.txt`

--- a/create_config.py
+++ b/create_config.py
@@ -22,7 +22,7 @@ options:
   base_path: .
   compiler: {rom.compiler}
   find_file_boundaries: True
-  header_encoding: {rom.encoding}
+  header_encoding: {rom.header_encoding}
   # platform: n64
   # undefined_funcs_auto_path: undefined_funcs_auto.txt
   # undefined_syms_auto_path: undefined_syms_auto.txt

--- a/create_config.py
+++ b/create_config.py
@@ -1,11 +1,12 @@
 #! /usr/bin/env python3
 
 import argparse
+from pathlib import Path
+
 from util.n64 import rominfo, find_code_length
 
-parser = argparse.ArgumentParser(description="Create a splat config from a ROM. "
-                                             "Only n64 .z64 ROMs are supported")
-parser.add_argument("rom", help="Path to a .z64 ROM")
+parser = argparse.ArgumentParser(description="Create a splat config from an N64 ROM.")
+parser.add_argument("rom", help="Path to a .z64/.n64 ROM")
 
 
 def main(rom_path):
@@ -17,10 +18,11 @@ name: {rom.name.title()} ({rom.get_country_name()})
 sha1: {rom.sha1}
 options:
   basename: {basename}
-  target_path: {rom_path}
+  target_path: {rom_path.with_suffix(".z64")}
   base_path: .
   compiler: {rom.compiler}
   find_file_boundaries: True
+  header_encoding: {rom.encoding}
   # platform: n64
   # undefined_funcs_auto_path: undefined_funcs_auto.txt
   # undefined_syms_auto_path: undefined_syms_auto.txt
@@ -57,10 +59,12 @@ segments:
   - [0x{rom.size:X}]
 """.lstrip()
 
-    with open(basename + ".yaml", "w", newline="\n") as f:
+    out_file = f"{basename}.yaml"
+    with open(out_file, "w", newline="\n") as f:
+        print(f"Writing config to {out_file}")
         f.write(header + segments)
 
 
 if __name__ == "__main__":
     args = parser.parse_args()
-    main(args.rom)
+    main(Path(args.rom))

--- a/segtypes/n64/header.py
+++ b/segtypes/n64/header.py
@@ -18,7 +18,7 @@ class N64SegHeader(CommonSegHeader):
         header_lines.append(self.get_line("word", rom_bytes[0x1C:0x20], "Unknown 2"))
 
         if encoding != "word":
-            header_lines.append(".ascii \"" + rom_bytes[0x20:0x34].decode(encoding).strip().ljust(20) + "\" /* Internal name */")
+            header_lines.append(f".ascii \"" + rom_bytes[0x20:0x34].decode(encoding).strip().ljust(20) + "\" /* Internal name */")
         else:
             for i in range(0x20, 0x34, 4):
                 header_lines.append(self.get_line("word", rom_bytes[i:i+4], "Internal name"))


### PR DESCRIPTION
e.g. before:
```
$ python3 util/n64/rominfo.py 'Bokujou Monogatari 2 (Japan).n64'
splat could not decode the game name; try using a different encoding by passing the --encoding argument (see docs.python.org/3/library/codecs.html#standard-encodings for valid encodings)
```

now:
```
$ python3 util/n64/rominfo.py 'Bokujou Monogatari 2 (Japan).n64'
Warning: Input file has .n64 suffix, byte-swapping!
Writing down Bokujou Monogatari 2 (Japan).z64
Image name: ﾎﾞｸｼﾞｮｳﾓﾉｶﾞﾀﾘ2
Country code: J - Japanese
Libultra version: I
CRC1: B3D451C6
CRC2: E1CB58E2
CIC: 6102 / 7101
RAM entry point: 0x80025c00
Encoding: shift_jis

0 branches and 3 jumps detected in the first code segment. Compiler is most likely GCC
```

NOTE: also handling for .n64 files which will be written down as .z64 assuming a file with that name does not already exist.

also added `encoding:` to config yaml:

```
$ python3 create_config.py 'Bokujou Monogatari 2 (Japan).n64'
Warning: Input file has .n64 suffix, byte-swapping!
Writing down Bokujou Monogatari 2 (Japan).z64
Writing config to ﾎﾞｸｼﾞｮｳﾓﾉｶﾞﾀﾘ2.yaml

$ cat "ﾎﾞｸｼﾞｮｳﾓﾉｶﾞﾀﾘ2.yaml"
name: ﾎﾞｸｼﾞｮｳﾓﾉｶﾞﾀﾘ2 (Japanese)
sha1: e41d15c394b5fefd4016add3883a794c48e7e232
options:
  basename: ﾎﾞｸｼﾞｮｳﾓﾉｶﾞﾀﾘ2
  target_path: Bokujou Monogatari 2 (Japan).z64
  base_path: .
  compiler: GCC
  find_file_boundaries: True
  header_encoding: shift_jis
  # platform: n64
  # undefined_funcs_auto_path: undefined_funcs_auto.txt
  # undefined_syms_auto_path: undefined_syms_auto.txt
  # symbol_addrs_path: symbol_addrs.txt
  # undefined_syms_path: undefined_syms.txt
  # asm_path: asm
  # src_path: src
  # build_path: build
  # extensions_path: tools/splat_ext
  # auto_all_sections: True
segments:
  - name: header
    type: header
    start: 0x0
  - name: boot
    type: bin
    start: 0x40
  - name: main
    type: code
    start: 0x1000
    vram: 0x80025C00
    subsegments:
      - [0x1000, asm]
  - type: bin
    start: 0x1010
  - [0x1000000]
```