### PR TITLE
Fixing a few bugs

### DIFF
--- a/util/color.py
+++ b/util/color.py
@@ -4,7 +4,7 @@ from util import options
 
 # RRRRRGGG GGBBBBBA
 def unpack_color(data):
-    s = int.from_bytes(data[0:2], byteorder=options.get_endianness())
+    s = int.from_bytes(data[0:2], byteorder=options.get_endianess())
 
     r = (s >> 11) & 0x1F
     g = (s >>  6) & 0x1F

--- a/util/symbols.py
+++ b/util/symbols.py
@@ -1,9 +1,8 @@
 from dataclasses import dataclass
-from logging import Logger
 from typing import Dict, List, Optional
 
 from capstone import CsInsn
-from util import options
+from util import options, log
 
 all_symbols: "List[Symbol]" = []
 symbol_ranges: "List[Symbol]" = []
@@ -51,17 +50,20 @@ def initialize(all_segments):
                         if info.startswith("type:"):
                             type = info.split(":")[1]
                             sym.type = type
+                            continue
                         if info.startswith("size:"):
                             size = int(info.split(":")[1], 0)
                             sym.size = size
+                            continue
                         if info.startswith("rom:"):
                             rom_addr = int(info.split(":")[1], 0)
                             sym.rom = rom_addr
+                            continue
 
                         val = str(info.split(":")[1])
                         tf_val = True if is_truey(val) else False if is_falsey(val) else None
                         if tf_val is None:
-                            Logger.error(f"Invalid value {val} for attribute on line: {line}")
+                            log.error(f"Invalid value {val} for attribute on line: {line}")
 
                         if info.startswith("dead:"):
                             sym.dead = tf_val or False


### PR DESCRIPTION
the `log` change is to fix:
```
# python3 tools/splat/split.py sssv.us.yaml
splat 0.8.0.0
Loading and processing symbols
Traceback (most recent call last):
  File "tools/splat/split.py", line 314, in <module>
    main(args.config, args.basedir, args.target, args.modes, args.verbose, args.use_cache)
  File "tools/splat/split.py", line 201, in main
    symbols.initialize(all_segments)
  File "/sssv/tools/splat/util/symbols.py", line 64, in initialize
    Logger.error(f"Invalid value {val} for attribute on line: {line}")
TypeError: error() missing 1 required positional argument: 'msg'
make: *** [Makefile:168: extract] Error 1
```

the `continue` change is to fix:

```
# python3 tools/splat/split.py sssv.us.yaml
splat 0.8.0.0
Loading and processing symbols
Invalid value 0x6ABC64 for attribute on line: set_fog_factor_and_color   = 0x8029A5B4;
make: *** [Makefile:168: extract] Error 2
```

the `endianess` change is fixing a typo:
```
python3 tools/splat/split.py sssv.us.yaml
splat 0.8.0.0
Loading and processing symbols
Starting scan
..........................................................................................................................................................................................................................................................................................................................................
Starting split
..Traceback (most recent call last):
  File "tools/splat/split.py", line 314, in <module>
    main(args.config, args.basedir, args.target, args.modes, args.verbose, args.use_cache)
  File "tools/splat/split.py", line 255, in main
    segment.split(rom_bytes)
  File "/sssv/tools/splat/segtypes/common/group.py", line 224, in split
    sub.split(rom_bytes)
  File "/sssv/tools/splat/segtypes/n64/rgba16.py", line 16, in split
    w.write_array(f, self.parse_image(data, self.width, self.height, self.flip_horizontal, self.flip_vertical))
  File "/sssv/tools/splat/segtypes/n64/rgba16.py", line 29, in parse_image
    img += bytes(unpack_color(data[i:]))
  File "/sssv/tools/splat/util/color.py", line 7, in unpack_color
    s = int.from_bytes(data[0:2], byteorder=options.get_endianness())
AttributeError: module 'util.options' has no attribute 'get_endianness'
```