### PR TITLE
Options for changing data and nonmatchings' directiories

### DIFF
--- a/segtypes/common/c.py
+++ b/segtypes/common/c.py
@@ -208,7 +208,7 @@ class CommonSegC(CommonSegCodeSubsegment):
                     else:
                         c_lines.append("INCLUDE_ASM(\"{}\", {});".format(asm_out_dir / self.name, func_name))
                 else:
-                    asm_outpath = Path(os.path.join(asm_out_dir, self.dir, self.name, func_name + ".s"))
+                    asm_outpath = Path(os.path.join(asm_out_dir, self.name, func_name + ".s"))
                     rel_asm_outpath = os.path.relpath(asm_outpath, options.get_base_path())
                     c_lines.append(f"#pragma GLOBAL_ASM(\"{rel_asm_outpath}\")")
             c_lines.append("")

--- a/segtypes/common/c.py
+++ b/segtypes/common/c.py
@@ -109,7 +109,7 @@ class CommonSegC(CommonSegCodeSubsegment):
     def split(self, rom_bytes: bytes):
         if not self.rom_start == self.rom_end:
 
-            asm_out_dir = options.get_asm_path() / "nonmatchings" / self.dir
+            asm_out_dir = options.get_nonmatchings_path() / self.dir
             asm_out_dir.mkdir(parents=True, exist_ok=True)
 
             is_new_c_file = False

--- a/segtypes/common/data.py
+++ b/segtypes/common/data.py
@@ -17,7 +17,7 @@ class CommonSegData(CommonSegCodeSubsegment, CommonSegGroup):
                 return options.get_src_path() / self.dir / f"{self.name}.c"
         else:
             # ASM
-            return options.get_asm_path() / "data" / self.dir / f"{self.name}.{self.type}.s"
+            return options.get_data_path() / self.dir / f"{self.name}.{self.type}.s"
 
     def scan(self, rom_bytes: bytes):
         CommonSegGroup.scan(self, rom_bytes)

--- a/split.py
+++ b/split.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#! /usr/bin/env python3
 
 import hashlib
 from typing import Dict, List, Union, Set, Any

--- a/util/n64/find_code_length.py
+++ b/util/n64/find_code_length.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#! /usr/bin/env python3
 
 from capstone import *
 

--- a/util/n64/rominfo.py
+++ b/util/n64/rominfo.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#! /usr/bin/env python3
 
 import argparse
 import itertools

--- a/util/options.py
+++ b/util/options.py
@@ -111,6 +111,14 @@ def get_src_path() -> Path:
 def get_asm_path() -> Path:
     return get_base_path() / opts.get("asm_path", "asm")
 
+# Determines the path to the asm data directory
+def get_data_path() -> Path:
+    return get_base_path() / opts.get("data_path", get_asm_path() / "data")
+
+# Determines the path to the asm nonmatchings directory
+def get_nonmatchings_path() -> Path:
+    return get_base_path() / opts.get("nonmatchings_path", get_asm_path() / "nonmatchings")
+
 # Determines the path to the cache file (used when supplied --use-cache via the CLI)
 def get_cache_path():
     return get_base_path() / opts.get("cache_path", ".splat_cache")


### PR DESCRIPTION
Add `data_path` and `nonmatchings_path` options to specify directories to put these two in, rather than hardcoding them in the functions. Defaults to current behaviour if not specified.

Also fixed a bug where the dir was printed twice in the `GLOBAL_ASM` statement in the C files, and made all the #!s `/usr/bin/env python3` since apparently this is the more correct way.