### PR TITLE
Cleanup/fixup/refactor create_config related code

### DIFF
--- a/create_config.py
+++ b/create_config.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python3
 
+import sys
 import argparse
 from pathlib import Path
 
@@ -9,11 +10,17 @@ parser = argparse.ArgumentParser(description="Create a splat config from an N64 
 parser.add_argument("rom", help="Path to a .z64/.n64 ROM")
 
 
-def main(rom_path):
-    rom = rominfo.get_info(rom_path)
+def main(rom_path: Path):
+    if not rom_path.exists():
+        sys.exit(f"ROM file {rom_path} does not exist ({rom_path.absolute()})")
+    if rom_path.is_dir():
+        sys.exit(f"Path {rom_path} is a directory ({rom_path.absolute()})")
+    rom_bytes = rominfo.read_rom(rom_path)
+
+    rom = rominfo.get_info(rom_path, rom_bytes)
     basename = rom.name.replace(" ", "").lower()
 
-    header = f"""
+    header = f"""\
 name: {rom.name.title()} ({rom.get_country_name()})
 sha1: {rom.sha1}
 options:
@@ -33,14 +40,11 @@ options:
   # build_path: build
   # extensions_path: tools/splat_ext
   # auto_all_sections: True
-""".lstrip()
+"""
 
-    with open(rom_path, "rb") as f:
-        fbytes = f.read()
+    first_section_end = find_code_length.run(rom_bytes, 0x1000, rom.entry_point)
 
-    first_section_end = find_code_length.run(fbytes, 0x1000, rom.entry_point)
-
-    segments = f"""
+    segments = f"""\
 segments:
   - name: header
     type: header
@@ -57,12 +61,13 @@ segments:
   - type: bin
     start: 0x{first_section_end:X}
   - [0x{rom.size:X}]
-""".lstrip()
+"""
 
     out_file = f"{basename}.yaml"
     with open(out_file, "w", newline="\n") as f:
         print(f"Writing config to {out_file}")
-        f.write(header + segments)
+        f.write(header)
+        f.write(segments)
 
 
 if __name__ == "__main__":

--- a/util/n64/find_code_length.py
+++ b/util/n64/find_code_length.py
@@ -1,22 +1,27 @@
 #! /usr/bin/env python3
 
-from capstone import *
-
 from capstone import Cs, CS_ARCH_MIPS, CS_MODE_MIPS64, CS_MODE_BIG_ENDIAN
-from capstone.mips import *
 
 import argparse
 
 md = Cs(CS_ARCH_MIPS, CS_MODE_MIPS64 + CS_MODE_BIG_ENDIAN)
 
+
+def int_any_base(x):
+    return int(x, 0)
+
+
 parser = argparse.ArgumentParser(
     description="Given a rom and start offset, find where the code ends"
 )
 parser.add_argument("rom", help="path to a .z64 rom")
-parser.add_argument("start", help="start offset")
-parser.add_argument("--end", help="end offset", default=None)
+parser.add_argument("start", help="start offset", type=int_any_base)
+parser.add_argument("--end", help="end offset", default=None, type=int_any_base)
 parser.add_argument(
-    "--vram", help="vram address to start disassembly at", default="0x80000000"
+    "--vram",
+    help="vram address to start disassembly at",
+    default="0x80000000",
+    type=int_any_base,
 )
 
 
@@ -31,21 +36,23 @@ def run(rom_bytes, start_offset, vram, end_offset=None):
         if end_offset and rom_addr >= end_offset:
             break
 
-    return last_return + (0x10 - (last_return % 0x10))
+    # align to next 0x10 boundary
+    end = last_return + 0x10
+    end -= end % 0x10
+    return end
 
 
 def main():
     args = parser.parse_args()
 
-    rom_bytes = open(args.rom, "rb").read()
-    start = int(args.start, 0)
-    end = None
-    vram = int(args.vram, 0)
+    with open(args.rom, "rb") as f:
+        rom_bytes = f.read()
 
-    if args.end:
-        end = int(args.end, 0)
+    start = args.start
+    end = args.end
+    vram = args.vram
 
-    print(f"{run(rom_bytes, start, vram, end):X}")
+    print(f"0x{run(rom_bytes, start, vram, end):X}")
 
 
 if __name__ == "__main__":

--- a/util/n64/rominfo.py
+++ b/util/n64/rominfo.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python3
 
+import sys
 import argparse
 import itertools
 import struct
@@ -15,7 +16,11 @@ parser = argparse.ArgumentParser(description="Gives information on N64 roms")
 parser.add_argument("rom", help="path to an N64 rom")
 parser.add_argument(
     "--header-encoding",
-    help="Text encoding the game header is using; see docs.python.org/3/library/codecs.html#standard-encodings for valid encodings",
+    dest="header_encoding",
+    help=(
+        "Text encoding the game header is using;"
+        " see docs.python.org/3/library/codecs.html#standard-encodings for valid encodings"
+    ),
 )
 
 country_codes = {
@@ -42,27 +47,39 @@ country_codes = {
     0x59: "European",
 }
 
+
+class CIC:
+    def __init__(
+        self,
+        ntsc_name: str,
+        pal_name: str,
+        offset: int,
+    ):
+        self.ntsc_name = ntsc_name
+        self.pal_name = pal_name
+        self.offset = offset
+
+
 crc_to_cic = {
-    0x6170A4A1: {"ntsc-name": "6101", "pal-name": "7102", "offset": 0x000000},
-    0x90BB6CB5: {"ntsc-name": "6102", "pal-name": "7101", "offset": 0x000000},
-    0x0B050EE0: {"ntsc-name": "6103", "pal-name": "7103", "offset": 0x100000},
-    0x98BC2C86: {"ntsc-name": "6105", "pal-name": "7105", "offset": 0x000000},
-    0xACC8580A: {"ntsc-name": "6106", "pal-name": "7106", "offset": 0x200000},
-    0x00000000: {"ntsc-name": "unknown", "pal-name": "unknown", "offset": 0x0000000},
+    0x6170A4A1: CIC("6101", "7102", 0x000000),
+    0x90BB6CB5: CIC("6102", "7101", 0x000000),
+    0x0B050EE0: CIC("6103", "7103", 0x100000),
+    0x98BC2C86: CIC("6105", "7105", 0x000000),
+    0xACC8580A: CIC("6106", "7106", 0x200000),
 }
+unknown_cic = CIC("unknown", "unknown", 0x0000000)
 
 
 def swap_bytes(data):
     return bytes(
         itertools.chain.from_iterable(
-            struct.pack(">H", x) for x, in struct.iter_unpack("<H", data)
+            struct.pack(">H", x) for (x,) in struct.iter_unpack("<H", data)
         )
     )
 
 
-def read_rom(rom_path):
-    with open(rom_path, "rb") as f:
-        rom_bytes = f.read()
+def read_rom(rom_path: Path):
+    rom_bytes = rom_path.read_bytes()
 
     if rom_path.suffix.lower() == ".n64":
         print("Warning: Input file has .n64 suffix, byte-swapping!")
@@ -70,24 +87,21 @@ def read_rom(rom_path):
         as_z64 = rom_path.with_suffix(".z64")
         if not as_z64.exists():
             print(f"Writing down {as_z64}")
-            with open(as_z64, "wb") as o:
-                o.write(rom_bytes)
+            as_z64.write_bytes(rom_bytes)
     return rom_bytes
 
 
-def get_cic(rom_bytes):
-    crc = zlib.crc32(rom_bytes[0x40:0x1000])
-    if crc in crc_to_cic:
-        return crc_to_cic[crc]
-    else:
-        return crc_to_cic[0]
+def get_cic(rom_bytes: bytes):
+    ipl3_crc = zlib.crc32(rom_bytes[0x40:0x1000])
+
+    return crc_to_cic.get(ipl3_crc, unknown_cic)
 
 
-def get_entry_point(program_counter, cic):
-    return program_counter - cic["offset"]
+def get_entry_point(program_counter: int, cic: CIC):
+    return program_counter - cic.offset
 
 
-def guess_header_encoding(rom_bytes):
+def guess_header_encoding(rom_bytes: bytes):
     header = rom_bytes[0x20:0x34]
     encodings = ["ASCII", "shift_jis", "euc-jp"]
     for encoding in encodings:
@@ -98,12 +112,11 @@ def guess_header_encoding(rom_bytes):
             # we guessed wrong...
             pass
 
-    print("Unknown header encoding, please raise an Issue with us")
-    exit(1)
+    sys.exit("Unknown header encoding, please raise an Issue with us")
 
 
-def get_info(rom_path, rom_bytes=None, header_encoding=None):
-    if not rom_bytes:
+def get_info(rom_path: Path, rom_bytes: bytes = None, header_encoding=None):
+    if rom_bytes is None:
         rom_bytes = read_rom(rom_path)
 
     if header_encoding is None:
@@ -112,19 +125,19 @@ def get_info(rom_path, rom_bytes=None, header_encoding=None):
     return get_info_bytes(rom_bytes, header_encoding)
 
 
-def get_info_bytes(rom_bytes, header_encoding):
-    program_counter = int(rom_bytes[0x8:0xC].hex(), 16)
+def get_info_bytes(rom_bytes: bytes, header_encoding):
+    (program_counter,) = struct.unpack(">I", rom_bytes[0x8:0xC])
     libultra_version = chr(rom_bytes[0xF])
-    crc1 = rom_bytes[0x10:0x14].hex().upper()
-    crc2 = rom_bytes[0x14:0x18].hex().upper()
+    checksum = rom_bytes[0x10:0x18].hex().upper()
 
     try:
         name = rom_bytes[0x20:0x34].decode(header_encoding).strip()
     except:
-        print(
-            "splat could not decode the game name; try using a different encoding by passing the --header-encoding argument (see docs.python.org/3/library/codecs.html#standard-encodings for valid encodings)"
+        sys.exit(
+            "splat could not decode the game name;"
+            " try using a different encoding by passing the --header-encoding argument"
+            " (see docs.python.org/3/library/codecs.html#standard-encodings for valid encodings)"
         )
-        exit(1)
 
     country_code = rom_bytes[0x3E]
 
@@ -146,8 +159,7 @@ def get_info_bytes(rom_bytes, header_encoding):
         header_encoding,
         country_code,
         libultra_version,
-        crc1,
-        crc2,
+        checksum,
         cic,
         entry_point,
         len(rom_bytes),
@@ -159,15 +171,14 @@ def get_info_bytes(rom_bytes, header_encoding):
 class N64Rom:
     def __init__(
         self,
-        name,
+        name: str,
         header_encoding,
         country_code,
         libultra_version,
-        crc1,
-        crc2,
-        cic,
-        entry_point,
-        size,
+        checksum,
+        cic: CIC,
+        entry_point: int,
+        size: int,
         compiler,
         sha1,
     ):
@@ -175,8 +186,7 @@ class N64Rom:
         self.header_encoding = header_encoding
         self.country_code = country_code
         self.libultra_version = libultra_version
-        self.crc1 = crc1
-        self.crc2 = crc2
+        self.checksum = checksum
         self.cic = cic
         self.entry_point = entry_point
         self.size = size
@@ -187,7 +197,7 @@ class N64Rom:
         return country_codes[self.country_code]
 
 
-def get_compiler_info(rom_bytes, entry_point, print_result=True):
+def get_compiler_info(rom_bytes: bytes, entry_point: int, print_result=True):
     md = Cs(CS_ARCH_MIPS, CS_MODE_MIPS64 + CS_MODE_BIG_ENDIAN)
     md.detail = True
 
@@ -203,12 +213,12 @@ def get_compiler_info(rom_bytes, entry_point, print_result=True):
     compiler = "IDO" if branches > jumps else "GCC"
     if print_result:
         print(
-            f"{branches} branches and {jumps} jumps detected in the first code segment. Compiler is most likely {compiler}"
+            f"{branches} branches and {jumps} jumps detected in the first code segment."
+            f" Compiler is most likely {compiler}"
         )
     return compiler
 
 
-# TODO: support .n64 extension
 def main():
     args = parser.parse_args()
     rom_bytes = read_rom(Path(args.rom))
@@ -217,9 +227,8 @@ def main():
     print("Image name: " + rom.name)
     print("Country code: " + chr(rom.country_code) + " - " + rom.get_country_name())
     print("Libultra version: " + rom.libultra_version)
-    print("CRC1: " + rom.crc1)
-    print("CRC2: " + rom.crc2)
-    print("CIC: " + rom.cic["ntsc-name"] + " / " + rom.cic["pal-name"])
+    print("Checksum: " + rom.checksum)
+    print("CIC: " + rom.cic.ntsc_name + " / " + rom.cic.pal_name)
     print("RAM entry point: " + hex(rom.entry_point))
     print("Header encoding: " + rom.header_encoding)
     print("")

--- a/util/n64/rominfo.py
+++ b/util/n64/rominfo.py
@@ -1,5 +1,7 @@
 #! /usr/bin/env python3
 
+from dataclasses import dataclass
+
 import sys
 import argparse
 import itertools
@@ -48,16 +50,11 @@ country_codes = {
 }
 
 
+@dataclass
 class CIC:
-    def __init__(
-        self,
-        ntsc_name: str,
-        pal_name: str,
-        offset: int,
-    ):
-        self.ntsc_name = ntsc_name
-        self.pal_name = pal_name
-        self.offset = offset
+    ntsc_name: str
+    pal_name: str
+    offset: int
 
 
 crc_to_cic = {


### PR DESCRIPTION
Non-important changes to make the code look/behave better

- Generic Python cleanup
- String formatting changes
- More type annotations
- Check if rom file exists in `create_config`
- Change crc1/crc2 to "checksum" (see "Checksum" on https://n64brew.dev/wiki/ROM_Header , specifically *"Sometimes, these 8 bytes are referred to as "CRC HI" / "CRC LO" or "CRC1/2", but the checksum algorithm is not a CRC, and splitting into two 4-byte words seem confusing when it is really a 64-bit value."*)
- Remove a `# TODO: support .n64 extension` as I think that's handled (in `rominfo.read_rom`)