### PR TITLE
Don't mark symbols as jtbls if any of its labels point to the start of its corresponding function

### DIFF
--- a/segtypes/common/data.py
+++ b/segtypes/common/data.py
@@ -239,10 +239,14 @@ class CommonSegData(CommonSegCodeSubsegment, CommonSegGroup):
             word = int.from_bytes(bytes[i : i + 4], options.get_endianess())
 
             # If the word doesn't contain an address in the current function, this isn't a valid jump table
-            if not jtbl_func.contains_vram(word) or word == jtbl_func.vram_start:
+            if not jtbl_func.contains_vram(word):
                 # Allow jump tables that are of a minimum length and end in 0s
                 if i < min_jtbl_len or any(b != 0 for b in bytes[i:]):
                     return False
+
+            # A label of a jump table shouldn't point to the start of the function
+            if word == jtbl_func.vram_start:
+                return False
 
         # Mark this symbol as a jump table and record the jump table for later
         sym.type = "jtbl"

--- a/segtypes/common/data.py
+++ b/segtypes/common/data.py
@@ -231,11 +231,15 @@ class CommonSegData(CommonSegCodeSubsegment, CommonSegGroup):
         if not jtbl_func:
             return False
 
+        # A label of a jump table shouldn't point to the start of the function
+        if word == jtbl_func.vram_start:
+            return False
+
         for i in range(4, len(bytes), 4):
             word = int.from_bytes(bytes[i : i + 4], options.get_endianess())
 
             # If the word doesn't contain an address in the current function, this isn't a valid jump table
-            if not jtbl_func.contains_vram(word):
+            if not jtbl_func.contains_vram(word) or word == jtbl_func.vram_start:
                 # Allow jump tables that are of a minimum length and end in 0s
                 if i < min_jtbl_len or any(b != 0 for b in bytes[i:]):
                     return False


### PR DESCRIPTION
This fixes a very specific case where splat misinterpreted an array of functions with a jump table. This situation could only happen if said array only contained multiple references to the same exact function.

Example from [Yoshi's Story repo](https://github.com/decompals/yoshis-story/):
```mips
glabel jtbl_800A6570
.word L80062D50_63950, L80062D50_63950, L80062D50_63950, L80062D50_63950, L80062D50_63950, 0, 0, 0
```
This could build without issue because splat was generating this extra label on the corresponding function:
```mips
glabel func_80062D50
glabel L80062D50_63950
/* 63950 80062D50 27BDFFE0 */  addiu      $sp, $sp, -0x20
```

With this fix:
```mips
glabel D_800A6570
.word func_80062D50, func_80062D50, func_80062D50, func_80062D50, func_80062D50, 0x00000000, 0x00000000, 0x00000000
```

```mips
glabel func_80062D50
/* 63950 80062D50 27BDFFE0 */  addiu      $sp, $sp, -0x20
```