### PR TITLE
ia16 segment bugfix

### DIFF
--- a/segtypes/n64/ia16.py
+++ b/segtypes/n64/ia16.py
@@ -1,9 +1,18 @@
 from segtypes.n64.ia4 import N64SegIa4
+from util import iter
 
 
 class N64SegIa16(N64SegIa4):
-    def parse_image(self, data):
-        return data
+    @staticmethod
+    def parse_image(data, width, height, flip_h=False, flip_v=False):
+        img = bytearray()
+
+        for x, y, i in iter.iter_image_indexes(width, height, 2, 1, flip_h, flip_v):
+            i1 = data[i]
+            a1 = data[i + 1]
+            img += bytes((i1, a1))
+
+        return img
 
     def max_length(self):
         return self.width * self.height * 2


### PR DESCRIPTION
this change is to fix:
```Traceback (most recent call last):
  File "/home/user/repo/papermario/tools/build/configure.py", line 788, in <module>
    configure.split(not args.no_split_assets, args.split_code, args.debug)
  File "/home/user/repo/papermario/tools/build/configure.py", line 244, in split
    split.main(
  File "/home/user/repo/papermario/tools/splat/split.py", line 373, in main
    segment.split(rom_bytes)
  File "/home/user/repo/papermario/tools/splat/segtypes/common/group.py", line 112, in split
    sub.split(rom_bytes)
  File "/home/user/repo/papermario/tools/splat/segtypes/common/data.py", line 33, in split
    CommonSegGroup.split(self, rom_bytes)
  File "/home/user/repo/papermario/tools/splat/segtypes/common/group.py", line 112, in split
    sub.split(rom_bytes)
  File "/home/user/repo/papermario/tools/splat/segtypes/n64/rgba16.py", line 18, in split
    self.parse_image(
TypeError: N64SegIa16.parse_image() takes 2 positional arguments but 6 were given```