### PR TITLE
Generate dependency files for C files

### DIFF
--- a/segtypes/common/c.py
+++ b/segtypes/common/c.py
@@ -169,7 +169,10 @@ class CommonSegC(CommonSegCodeSubsegment):
                     break
 
     def create_c_asm_file(
-        self, func: spimdisasm.mips.symbols.SymbolFunction, out_dir: Path, func_sym: Symbol
+        self,
+        func: spimdisasm.mips.symbols.SymbolFunction,
+        out_dir: Path,
+        func_sym: Symbol,
     ):
         outpath = out_dir / self.name / (func_sym.name + ".s")
         assert func.vram is not None
@@ -277,7 +280,9 @@ class CommonSegC(CommonSegCodeSubsegment):
             f.write("\n".join(c_lines))
         log.write(f"Wrote {self.name} to {c_path}")
 
-    def create_asm_dependencies_file(self, c_path: Path, asm_out_dir: Path, is_new_c_file: bool):
+    def create_asm_dependencies_file(
+        self, c_path: Path, asm_out_dir: Path, is_new_c_file: bool
+    ):
         if not options.get_create_asm_dependencies():
             return
         if not (len(self.global_asm_funcs) > 0 or is_new_c_file):

--- a/segtypes/common/c.py
+++ b/segtypes/common/c.py
@@ -278,6 +278,8 @@ class CommonSegC(CommonSegCodeSubsegment):
         log.write(f"Wrote {self.name} to {c_path}")
 
     def create_asm_dependencies_file(self, c_path: Path, asm_out_dir: Path, is_new_c_file: bool):
+        if not options.get_create_asm_dependencies():
+            return
         if not (len(self.global_asm_funcs) > 0 or is_new_c_file):
             return
 

--- a/segtypes/common/c.py
+++ b/segtypes/common/c.py
@@ -302,3 +302,4 @@ class CommonSegC(CommonSegCodeSubsegment):
                 if func_name in self.global_asm_funcs or is_new_c_file:
                     outpath = asm_out_dir / self.name / (func_name + ".s")
                     f.write(f" \\\n    {outpath}")
+            f.write("\n")

--- a/segtypes/n64/asm.py
+++ b/segtypes/n64/asm.py
@@ -14,7 +14,9 @@ class N64SegAsm(CommonSegAsm):
         ret.append(".set noat      /* allow manual use of $at */")
         ret.append(".set noreorder /* don't insert nops after branches */")
         if options.get_add_set_gp_64():
-            ret.append(".set gp=64     /* allow use of 64-bit general purpose registers */")
+            ret.append(
+                ".set gp=64     /* allow use of 64-bit general purpose registers */"
+            )
         ret.append("")
         preamble = options.get_generated_s_preamble()
         if preamble:

--- a/segtypes/n64/hasm.py
+++ b/segtypes/n64/hasm.py
@@ -14,7 +14,9 @@ class N64SegHasm(CommonSegHasm):
         ret.append(".set noat      /* allow manual use of $at */")
         ret.append(".set noreorder /* don't insert nops after branches */")
         if options.get_add_set_gp_64():
-            ret.append(".set gp=64     /* allow use of 64-bit general purpose registers */")
+            ret.append(
+                ".set gp=64     /* allow use of 64-bit general purpose registers */"
+            )
         ret.append("")
         preamble = options.get_generated_s_preamble()
         if preamble:

--- a/util/floats.py
+++ b/util/floats.py
@@ -3,7 +3,7 @@ import struct
 
 # From mips_to_c: https://github.com/matt-kempster/mips_to_c/blob/d208400cca045113dada3e16c0d59c50cdac4529/src/translate.py#L2085
 def format_f32_imm(num: int) -> str:
-    packed = struct.pack(">I", num & (2**32 - 1))
+    packed = struct.pack(">I", num & (2 ** 32 - 1))
     value = struct.unpack(">f", packed)[0]
 
     if not value or value == 4294967296.0:
@@ -58,5 +58,5 @@ def format_f32_imm(num: int) -> str:
 
 
 def format_f64_imm(num: int) -> str:
-    (value,) = struct.unpack(">d", struct.pack(">Q", num & (2**64 - 1)))
+    (value,) = struct.unpack(">d", struct.pack(">Q", num & (2 ** 64 - 1)))
     return str(value)

--- a/util/floats.py
+++ b/util/floats.py
@@ -3,7 +3,7 @@ import struct
 
 # From mips_to_c: https://github.com/matt-kempster/mips_to_c/blob/d208400cca045113dada3e16c0d59c50cdac4529/src/translate.py#L2085
 def format_f32_imm(num: int) -> str:
-    packed = struct.pack(">I", num & (2 ** 32 - 1))
+    packed = struct.pack(">I", num & (2**32 - 1))
     value = struct.unpack(">f", packed)[0]
 
     if not value or value == 4294967296.0:
@@ -58,5 +58,5 @@ def format_f32_imm(num: int) -> str:
 
 
 def format_f64_imm(num: int) -> str:
-    (value,) = struct.unpack(">d", struct.pack(">Q", num & (2 ** 64 - 1)))
+    (value,) = struct.unpack(">d", struct.pack(">Q", num & (2**64 - 1)))
     return str(value)

--- a/util/options.py
+++ b/util/options.py
@@ -352,7 +352,7 @@ def get_mips_abi_gpr() -> str:
 
 # Generate .asmproc.d dependency files for each C file which still reference functions in assembly files
 def get_create_asm_dependencies() -> bool:
-    return opts.get("create_asm_dependencies", True)
+    return opts.get("create_asm_dependencies", False)
 
 
 # Determines which ABI names to use for floating point registers

--- a/util/options.py
+++ b/util/options.py
@@ -350,6 +350,11 @@ def get_mips_abi_gpr() -> str:
     return opts.get("mips_abi_gpr", "o32")
 
 
+# Generate .asmproc.d dependency files for each C file which still reference functions in assembly files
+def get_create_asm_dependencies() -> bool:
+    return opts.get("create_asm_dependencies", True)
+
+
 # Determines which ABI names to use for floating point registers
 # Valid values: 'numeric', 'o32', 'n32', 'n64'
 # o32 is highly recommended, as it provides logically named registers for floating point instructions


### PR DESCRIPTION
Allows to splat generate `.asmproc.d` files, which adds Makefile dependencies for the C files on the corresponding assembly function files.

For example, if file `src/boot/2F80.c` still has `INCLUDE_ASM` for `func_800023B4` and `func_80002400`, then the `build/src/boot/2F80.d` file will be generated and will look like this:
```makefile
build/src/boot/2F80.o: \
    asm/nonmatchings/boot/2F80/func_800023B4.s \
    asm/nonmatchings/boot/2F80/func_80002400.s
```

This allows to add the following on the main Makefile, which will trigger the rebuilding of the corresponding C file if the assembly function is touched:
```makefile
DEP_FILES := $(O_FILES:.o=.asmproc.d)
-include $(DEP_FILES)
```

This setting is enabled by default, should be instead be off by default?
This setting can be enabled/disabled by setting `create_asm_dependencies` on the yaml file.
