### PR TITLE
Output a `_SIZE` symbol for each segment in the linker script

### DIFF
--- a/segtypes/linker_entry.py
+++ b/segtypes/linker_entry.py
@@ -211,9 +211,9 @@ class LinkerWriter:
                     entry in last_seen_sections
                     and section_labels[entry.section_type].started
                 ):
-                    self._write_symbol(
-                        f"{seg_name}{last_seen_sections[entry].upper()}_END", "."
-                    )
+                    seg_name_section = f"{seg_name}{last_seen_sections[entry].upper()}"
+                    self._write_symbol(f"{seg_name_section}_END", ".")
+                    self._write_symbol(f"{seg_name_section}_SIZE", f"ABSOLUTE({to_cname(seg_name_section)}_END - {to_cname(seg_name_section)}_START)")
                     section_labels[last_seen_sections[entry]].ended = True
 
                 self._end_block()

--- a/segtypes/linker_entry.py
+++ b/segtypes/linker_entry.py
@@ -234,7 +234,9 @@ class LinkerWriter:
 
                 # If this is the last entry of its type, add the END marker for the section we're ending
                 if entry in last_seen_sections:
-                    self._write_symbol(f"{seg_name}{cur_section.upper()}_END", ".")
+                    seg_name_section = f"{seg_name}{cur_section.upper()}"
+                    self._write_symbol(f"{seg_name_section}_END", ".")
+                    self._write_symbol(f"{seg_name_section}_SIZE", f"ABSOLUTE({to_cname(seg_name_section)}_END - {to_cname(seg_name_section)}_START)")
                     section_labels[cur_section].ended = True
 
             prev_section = cur_section

--- a/segtypes/linker_entry.py
+++ b/segtypes/linker_entry.py
@@ -213,7 +213,10 @@ class LinkerWriter:
                 ):
                     seg_name_section = f"{seg_name}{last_seen_sections[entry].upper()}"
                     self._write_symbol(f"{seg_name_section}_END", ".")
-                    self._write_symbol(f"{seg_name_section}_SIZE", f"ABSOLUTE({to_cname(seg_name_section)}_END - {to_cname(seg_name_section)}_START)")
+                    self._write_symbol(
+                        f"{seg_name_section}_SIZE",
+                        f"ABSOLUTE({to_cname(seg_name_section)}_END - {to_cname(seg_name_section)}_START)",
+                    )
                     section_labels[last_seen_sections[entry]].ended = True
 
                 self._end_block()
@@ -236,7 +239,10 @@ class LinkerWriter:
                 if entry in last_seen_sections:
                     seg_name_section = f"{seg_name}{cur_section.upper()}"
                     self._write_symbol(f"{seg_name_section}_END", ".")
-                    self._write_symbol(f"{seg_name_section}_SIZE", f"ABSOLUTE({to_cname(seg_name_section)}_END - {to_cname(seg_name_section)}_START)")
+                    self._write_symbol(
+                        f"{seg_name_section}_SIZE",
+                        f"ABSOLUTE({to_cname(seg_name_section)}_END - {to_cname(seg_name_section)}_START)",
+                    )
                     section_labels[cur_section].ended = True
 
             prev_section = cur_section
@@ -246,7 +252,10 @@ class LinkerWriter:
             if section.started and not section.ended:
                 seg_name_section = f"{seg_name}{section.name.upper()}"
                 self._write_symbol(f"{seg_name_section}_END", ".")
-                self._write_symbol(f"{seg_name_section}_SIZE", f"ABSOLUTE({to_cname(seg_name_section)}_END - {to_cname(seg_name_section)}_START)")
+                self._write_symbol(
+                    f"{seg_name_section}_SIZE",
+                    f"ABSOLUTE({to_cname(seg_name_section)}_END - {to_cname(seg_name_section)}_START)",
+                )
 
         all_bss = all(e.section == ".bss" for e in entries)
         self._end_segment(segment, next_segment, all_bss)

--- a/segtypes/linker_entry.py
+++ b/segtypes/linker_entry.py
@@ -244,7 +244,9 @@ class LinkerWriter:
         # End all un-ended sections
         for section in section_labels.values():
             if section.started and not section.ended:
-                self._write_symbol(f"{seg_name}_{section.name.upper()}_END", ".")
+                seg_name_section = f"{seg_name}{section.name.upper()}"
+                self._write_symbol(f"{seg_name_section}_END", ".")
+                self._write_symbol(f"{seg_name_section}_SIZE", f"ABSOLUTE({to_cname(seg_name_section)}_END - {to_cname(seg_name_section)}_START)")
 
         all_bss = all(e.section == ".bss" for e in entries)
         self._end_segment(segment, next_segment, all_bss)

--- a/segtypes/linker_entry.py
+++ b/segtypes/linker_entry.py
@@ -211,11 +211,13 @@ class LinkerWriter:
                     entry in last_seen_sections
                     and section_labels[entry.section_type].started
                 ):
-                    seg_name_section = f"{seg_name}{last_seen_sections[entry].upper()}"
+                    seg_name_section = to_cname(
+                        f"{seg_name}{last_seen_sections[entry].upper()}"
+                    )
                     self._write_symbol(f"{seg_name_section}_END", ".")
                     self._write_symbol(
                         f"{seg_name_section}_SIZE",
-                        f"ABSOLUTE({to_cname(seg_name_section)}_END - {to_cname(seg_name_section)}_START)",
+                        f"ABSOLUTE({seg_name_section}_END - {seg_name_section}_START)",
                     )
                     section_labels[last_seen_sections[entry]].ended = True
 
@@ -237,11 +239,11 @@ class LinkerWriter:
 
                 # If this is the last entry of its type, add the END marker for the section we're ending
                 if entry in last_seen_sections:
-                    seg_name_section = f"{seg_name}{cur_section.upper()}"
+                    seg_name_section = to_cname(f"{seg_name}{cur_section.upper()}")
                     self._write_symbol(f"{seg_name_section}_END", ".")
                     self._write_symbol(
                         f"{seg_name_section}_SIZE",
-                        f"ABSOLUTE({to_cname(seg_name_section)}_END - {to_cname(seg_name_section)}_START)",
+                        f"ABSOLUTE({seg_name_section}_END - {seg_name_section}_START)",
                     )
                     section_labels[cur_section].ended = True
 
@@ -250,11 +252,11 @@ class LinkerWriter:
         # End all un-ended sections
         for section in section_labels.values():
             if section.started and not section.ended:
-                seg_name_section = f"{seg_name}{section.name.upper()}"
+                seg_name_section = to_cname(f"{seg_name}{section.name.upper()}")
                 self._write_symbol(f"{seg_name_section}_END", ".")
                 self._write_symbol(
                     f"{seg_name_section}_SIZE",
-                    f"ABSOLUTE({to_cname(seg_name_section)}_END - {to_cname(seg_name_section)}_START)",
+                    f"ABSOLUTE({seg_name_section}_END - {seg_name_section}_START)",
                 )
 
         all_bss = all(e.section == ".bss" for e in entries)


### PR DESCRIPTION
This can be useful to reference the size of a segment in a C/Assembly file.
The generated symbol will look like this in the linker script
```
        boot_BSS_SIZE = ABSOLUTE(boot_BSS_END - boot_BSS_START);
```
And like this in the map file
```
                0x0000000000018de0                boot_BSS_SIZE = ABSOLUTE ((boot_BSS_END - boot_BSS_START))
```