### PR TITLE
Allow setting the encoding for string disassembly

### DIFF
--- a/segtypes/common/codesubsegment.py
+++ b/segtypes/common/codesubsegment.py
@@ -21,6 +21,8 @@ class CommonSegCodeSubsegment(Segment):
             else False
         )
 
+        self.str_encoding: Optional[str] = self.yaml.get("str_encoding", False) if isinstance(self.yaml, dict) else None
+
         self.spim_section: Optional[spimdisasm.mips.sections.SectionBase] = None
 
     @property

--- a/segtypes/common/rodata.py
+++ b/segtypes/common/rodata.py
@@ -26,6 +26,12 @@ class CommonSegRodata(CommonSegData):
             self.get_exclusive_ram_id(),
         )
 
+        # Set rodata string encoding
+        # First check the global configuration
+        if options.opts.string_encoding is not None:
+            self.spim_section.stringEncoding = options.opts.string_encoding
+
+        # Then check the per-segment configuration in case we want to override the global one
         if self.str_encoding is not None:
             self.spim_section.stringEncoding = self.str_encoding
 

--- a/segtypes/common/rodata.py
+++ b/segtypes/common/rodata.py
@@ -26,6 +26,9 @@ class CommonSegRodata(CommonSegData):
             self.get_exclusive_ram_id(),
         )
 
+        if self.str_encoding is not None:
+            self.spim_section.stringEncoding = self.str_encoding
+
         self.spim_section.analyze()
         self.spim_section.setCommentOffset(self.rom_start)
 

--- a/util/options.py
+++ b/util/options.py
@@ -5,8 +5,6 @@ from typing import Dict, List, Mapping, Optional, Type, TypeVar
 from util import compiler
 from util.compiler import Compiler
 
-opts: "SplatOpts"
-
 
 @dataclass
 class SplatOpts:
@@ -146,6 +144,8 @@ class SplatOpts:
     add_set_gp_64: bool
     # Generate .asmproc.d dependency files for each C file which still reference functions in assembly files
     create_asm_dependencies: bool
+    # 
+    string_encoding: Optional[str]
 
     ################################################################################
     # N64-specific options
@@ -166,6 +166,8 @@ class SplatOpts:
     # Returns whether the given mode is currently enabled
     def is_mode_active(self, mode: str) -> bool:
         return mode in self.modes or "all" in self.modes
+
+opts: SplatOpts
 
 
 def parse_yaml(
@@ -196,6 +198,20 @@ def parse_yaml(
             if default is not None:
                 return default
             raise ValueError(f"Missing required option {opt}")
+        return yaml_as_type(value, t)
+
+    def parse_optional_opt(
+        yaml: Mapping[str, object],
+        opt: str,
+        t: Type[T],
+        default: Optional[T] = None,
+    ) -> Optional[T]:
+        value = yaml.get(opt)
+        if isinstance(value, t):
+            # Fast path
+            return value
+        if value is None and opt not in yaml:
+            return default
         return yaml_as_type(value, t)
 
     def parse_opt_within(
@@ -340,6 +356,7 @@ def parse_yaml(
         ),
         add_set_gp_64=parse_opt(yaml, "add_set_gp_64", bool, True),
         create_asm_dependencies=parse_opt(yaml, "create_asm_dependencies", bool, False),
+        string_encoding=parse_optional_opt(yaml, "string_encoding", str, None),
         header_encoding=parse_opt(yaml, "header_encoding", str, "ASCII"),
         gfx_ucode=parse_opt_within(
             yaml,

--- a/util/options.py
+++ b/util/options.py
@@ -144,7 +144,7 @@ class SplatOpts:
     add_set_gp_64: bool
     # Generate .asmproc.d dependency files for each C file which still reference functions in assembly files
     create_asm_dependencies: bool
-    # 
+    # Global option for rodata string encoding. This can be overriden per segment
     string_encoding: Optional[str]
 
     ################################################################################


### PR DESCRIPTION
Currently spimdisasm disassembles strings as if they were always encoded with EUC-JP encoding, this can be a bit problematic since some games uses other encodings for their strings.
This change allows telling spimdisasm the encoding we want to decode strings with.

There are a few options to do this:
- The first one is a global option one which would be applied to every rodata subsegment.
- Second one is setting the encoding in the corresponding rodata subsegment with `string_encoding: Shift-JIS`. Useful in case a game uses more multiples string encodings. This setting overrides the global one.
- Finally in case the user does not set the encoding in any way then spimdisasm will default to EUC-JP