### PR TITLE
Add option to automatically add libultra symbols and named hardware registers

### DIFF
--- a/create_config.py
+++ b/create_config.py
@@ -43,6 +43,8 @@ options:
   # mips_abi_float_regs: o32
   # section_order: [".text", ".data", ".rodata", ".bss"]
   # auto_all_sections: [".data", ".rodata", ".bss"]
+  # libultra_symbols: True
+  # hardware_regs: True
 """
 
     first_section_end = find_code_length.run(rom_bytes, 0x1000, rom.entry_point)

--- a/platforms/n64.py
+++ b/platforms/n64.py
@@ -4,5 +4,7 @@ from util import compiler, log, options, palettes, symbols
 def init(target_bytes: bytes):
     symbols.spim_context.fillDefaultBannedSymbols()
 
-    symbols.spim_context.globalSegment.fillLibultraSymbols()
-    symbols.spim_context.globalSegment.fillHardwareRegs(True)
+    if options.opts.libultra_symbols:
+        symbols.spim_context.globalSegment.fillLibultraSymbols()
+    if options.opts.hardware_regs:
+        symbols.spim_context.globalSegment.fillHardwareRegs(True)

--- a/platforms/n64.py
+++ b/platforms/n64.py
@@ -3,3 +3,6 @@ from util import compiler, log, options, palettes, symbols
 
 def init(target_bytes: bytes):
     symbols.spim_context.fillDefaultBannedSymbols()
+
+    symbols.spim_context.globalSegment.fillLibultraSymbols()
+    symbols.spim_context.globalSegment.fillHardwareRegs(True)

--- a/split.py
+++ b/split.py
@@ -18,6 +18,8 @@ from segtypes.segment import Segment
 from util import compiler, log, options, palettes, symbols
 
 VERSION = "0.12.2"
+# This value should be keep in sync with the version listed on requirements.txt
+SPIMDISASM_MIN = (1, 5, 6)
 
 parser = argparse.ArgumentParser(
     description="Split a rom given a rom, a config, and output directory"
@@ -251,6 +253,9 @@ def brief_seg_name(seg: Segment, limit: int, ellipsis="…") -> str:
 
 def main(config_path, modes, verbose, use_cache=True):
     global config
+
+    if spimdisasm.__version_info__ < SPIMDISASM_MIN:
+        log.error(f"splat {VERSION} requires as minimum spimdisasm {SPIMDISASM_MIN}, but the installed version is {spimdisasm.__version_info__}")
 
     log.write(f"splat {VERSION} (powered by spimdisasm {spimdisasm.__version__})")
 

--- a/split.py
+++ b/split.py
@@ -255,7 +255,9 @@ def main(config_path, modes, verbose, use_cache=True):
     global config
 
     if spimdisasm.__version_info__ < SPIMDISASM_MIN:
-        log.error(f"splat {VERSION} requires as minimum spimdisasm {SPIMDISASM_MIN}, but the installed version is {spimdisasm.__version_info__}")
+        log.error(
+            f"splat {VERSION} requires as minimum spimdisasm {SPIMDISASM_MIN}, but the installed version is {spimdisasm.__version_info__}"
+        )
 
     log.write(f"splat {VERSION} (powered by spimdisasm {spimdisasm.__version__})")
 

--- a/util/options.py
+++ b/util/options.py
@@ -155,6 +155,10 @@ class SplatOpts:
     # Determines the type gfx ucode (used by gfx segments)
     # Valid options are ['f3d', 'f3db', 'f3dex', 'f3dexb', 'f3dex2']
     gfx_ucode: str
+    # Use named libultra symbols by default. Those will need to be added to a linker script manually by the user
+    libultra_symbols: bool
+    # Use named hardware register symbols by default. Those will need to be added to a linker script manually by the user
+    hardware_regs: bool
 
     ################################################################################
     # Compiler-specific options
@@ -366,6 +370,8 @@ def parse_yaml(
             ["f3d", "f3db", "f3dex", "f3dexb", "f3dex2"],
             "f3dex2",
         ),
+        libultra_symbols=parse_opt(yaml, "libultra_symbols", bool, False),
+        hardware_regs=parse_opt(yaml, "hardware_regs", bool, False),
         use_legacy_include_asm=parse_opt(yaml, "use_legacy_include_asm", bool, True),
     )
 

--- a/util/symbols.py
+++ b/util/symbols.py
@@ -383,6 +383,9 @@ def create_symbol_from_spim_symbol(
         context_sym.vram, in_segment, type=sym_type, reference=True
     )
 
+    if sym.given_name is None and context_sym.name is not None:
+        sym.given_name = context_sym.name
+
     # To keep the symbol name in sync between splat and spimdisasm
     context_sym.setNameGetCallback(lambda _: sym.name)
 


### PR DESCRIPTION
`spimdisasm` has those symbols by baked into it, so why not?
This option is turned off by default because the user will need to add those symbols to a linker script manually.

I also added a check for the minimal `spimdisasm` version which splat requires