### PR TITLE
Remove comments for psx assembly preamble

### DIFF
--- a/segtypes/common/sbss.py
+++ b/segtypes/common/sbss.py
@@ -1,0 +1,6 @@
+from segtypes.common.data import CommonSegData
+
+
+class CommonSegSbss(CommonSegData):
+    def get_linker_section(self) -> str:
+        return ".sbss"

--- a/segtypes/common/sdata.py
+++ b/segtypes/common/sdata.py
@@ -1,0 +1,6 @@
+from segtypes.common.data import CommonSegData
+
+
+class CommonSegSdata(CommonSegData):
+    def get_linker_section(self) -> str:
+        return ".sdata"

--- a/segtypes/psx/asm.py
+++ b/segtypes/psx/asm.py
@@ -10,9 +10,8 @@ class PsxSegAsm(CommonSegAsm):
 
         ret.append('.include "macro.inc"')
         ret.append("")
-        ret.append("/* assembler directives */")
-        ret.append(".set noat      /* allow manual use of $at */")
-        ret.append(".set noreorder /* don't insert nops after branches */")
+        ret.append(".set noat")
+        ret.append(".set noreorder")
         ret.append("")
         preamble = options.opts.generated_s_preamble
         if preamble:


### PR DESCRIPTION
Creating a PR for comments. `.sbss` shouldnt be included in the output (they should be DISCARD'd), however ESA devs were dumb and they include both `.sbss` and `.bss` in the binary (wasted space of pure zeroes) - so this change works for me, but would likely need extending for anyone with a psx decomp with better developers :)