### PR TITLE
Fix spimdisasm not seeing some symbols on its latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # splat Release Notes
 
+### 0.12.5
+
+* Update minimal spimdisasm version to 1.7.1.
+* Fix spimdisasm>=1.7.0 non being able to see symbols which only are referenced by other data symbols.
+* An check was added to prevent segments marked with `exclusive_ram_id` have a vram address range which overlaps with segments not marked with said tag. If this happens it will be warned to the user.
+
 ### 0.12.4
 * Fixed a bug involving the order of attributes in symbol_addrs preventing proper range searching during calls to `get_symbol`
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ pylibyaml
 tqdm
 intervaltree
 colorama
-spimdisasm>=1.5.6
-rabbitizer>=1.2.0
+# This value should be keep in sync with the version listed on split.py
+spimdisasm>=1.7.1
+rabbitizer>=1.3.1
 pygfxd
 n64img>=0.1.2

--- a/split.py
+++ b/split.py
@@ -17,9 +17,9 @@ from segtypes.linker_entry import LinkerWriter, to_cname
 from segtypes.segment import RomAddr, Segment
 from util import compiler, log, options, palettes, symbols
 
-VERSION = "0.12.4"
+VERSION = "0.12.5"
 # This value should be keep in sync with the version listed on requirements.txt
-SPIMDISASM_MIN = (1, 5, 6)
+SPIMDISASM_MIN = (1, 7, 1)
 
 parser = argparse.ArgumentParser(
     description="Split a rom given a rom, a config, and output directory"

--- a/util/symbols.py
+++ b/util/symbols.py
@@ -255,7 +255,7 @@ def initialize_spim_context(all_segments: "List[Segment]") -> None:
         and global_vrom_start is not None
         and global_vrom_end is not None
     ):
-        spim_context.globalSegment.changeRanges(
+        spim_context.changeGlobalSegmentRanges(
             global_vrom_start, global_vrom_end, global_vram_start, global_vram_end
         )
 

--- a/util/symbols.py
+++ b/util/symbols.py
@@ -265,11 +265,7 @@ def initialize_spim_context(all_segments: "List[Segment]") -> None:
         # Check the vram range of the global segment does not overlap with any overlay segment
         for ovl_segment in overlay_segments:
             assert ovl_segment.vramStart <= ovl_segment.vramEnd, f"{ovl_segment.vramStart:X} {ovl_segment.vramEnd:X}"
-            if ovl_segment.vramStart >= global_vram_end and ovl_segment.vramEnd >= global_vram_end:
-                pass
-            elif ovl_segment.vramStart < global_vram_start and ovl_segment.vramEnd < global_vram_start:
-                pass
-            else:
+            if ovl_segment.vramEnd > global_vram_start and global_vram_end > ovl_segment.vramStart:
                 log.write(f"Warning: the vram range ([0x{ovl_segment.vramStart:X}, 0x{ovl_segment.vramEnd:X}]) of the non-global segment at rom address 0x{ovl_segment.vromStart:X} overlaps with the global vram range ([0x{global_vram_start:X}, 0x{global_vram_end:X}])", status="warn")
 
     # pass the global symbols to spimdisasm

--- a/util/symbols.py
+++ b/util/symbols.py
@@ -196,6 +196,7 @@ def initialize_spim_context(all_segments: "List[Segment]") -> None:
     global_vrom_end = None
     global_vram_start = None
     global_vram_end = None
+    overlay_segments: Set[spimdisasm.common.SymbolsSegment] = set()
 
     spim_context.bannedSymbols |= ignored_addresses
 
@@ -249,6 +250,8 @@ def initialize_spim_context(all_segments: "List[Segment]") -> None:
                 for sym in symbols_list:
                     add_symbol_to_spim_segment(spim_segment, sym)
 
+            overlay_segments.add(spim_segment)
+
     if (
         global_vram_start is not None
         and global_vram_end is not None
@@ -258,6 +261,16 @@ def initialize_spim_context(all_segments: "List[Segment]") -> None:
         spim_context.changeGlobalSegmentRanges(
             global_vrom_start, global_vrom_end, global_vram_start, global_vram_end
         )
+
+        # Check the vram range of the global segment does not overlap with any overlay segment
+        for ovl_segment in overlay_segments:
+            assert ovl_segment.vramStart <= ovl_segment.vramEnd, f"{ovl_segment.vramStart:X} {ovl_segment.vramEnd:X}"
+            if ovl_segment.vramStart >= global_vram_end and ovl_segment.vramEnd >= global_vram_end:
+                pass
+            elif ovl_segment.vramStart < global_vram_start and ovl_segment.vramEnd < global_vram_start:
+                pass
+            else:
+                log.write(f"Warning: the vram range ([0x{ovl_segment.vramStart:X}, 0x{ovl_segment.vramEnd:X}]) of the non-global segment at rom address 0x{ovl_segment.vromStart:X} overlaps with the global vram range ([0x{global_vram_start:X}, 0x{global_vram_end:X}])", status="warn")
 
     # pass the global symbols to spimdisasm
     for segment in all_segments:

--- a/util/symbols.py
+++ b/util/symbols.py
@@ -264,9 +264,17 @@ def initialize_spim_context(all_segments: "List[Segment]") -> None:
 
         # Check the vram range of the global segment does not overlap with any overlay segment
         for ovl_segment in overlay_segments:
-            assert ovl_segment.vramStart <= ovl_segment.vramEnd, f"{ovl_segment.vramStart:X} {ovl_segment.vramEnd:X}"
-            if ovl_segment.vramEnd > global_vram_start and global_vram_end > ovl_segment.vramStart:
-                log.write(f"Warning: the vram range ([0x{ovl_segment.vramStart:X}, 0x{ovl_segment.vramEnd:X}]) of the non-global segment at rom address 0x{ovl_segment.vromStart:X} overlaps with the global vram range ([0x{global_vram_start:X}, 0x{global_vram_end:X}])", status="warn")
+            assert (
+                ovl_segment.vramStart <= ovl_segment.vramEnd
+            ), f"{ovl_segment.vramStart:X} {ovl_segment.vramEnd:X}"
+            if (
+                ovl_segment.vramEnd > global_vram_start
+                and global_vram_end > ovl_segment.vramStart
+            ):
+                log.write(
+                    f"Warning: the vram range ([0x{ovl_segment.vramStart:X}, 0x{ovl_segment.vramEnd:X}]) of the non-global segment at rom address 0x{ovl_segment.vromStart:X} overlaps with the global vram range ([0x{global_vram_start:X}, 0x{global_vram_end:X}])",
+                    status="warn",
+                )
 
     # pass the global symbols to spimdisasm
     for segment in all_segments:


### PR DESCRIPTION
A change introduced in spimdisasm version 1.7.0 prevented its data analyzer to see symbols which were only referenced by data symbols because the allowed vram ranges were changed to not be hardcodded, meaning it must be configured during setup. This PR addresses this problem. Addressing this implies bumping the minimal required spimdisasm version to 1.7.1

I also added a check to prevent segments tagged with `exclusive_ram_id` to have an overlapping VRAM range with non `exclusive_ram_id` segments. I didn't know if this should be an error and halt the execution or just warn to the user and let them do whatever they want, but I ended up opting for warning the user and letting them go ahead