### PR TITLE
IPL3 and RSP segments & PS2 platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # splat Release Notes
 
+### 0.12.6
+
+* Adds two new N64-specific segments:
+  * IPL3: Allows setting its correct VRAM address without messing the global segment detection
+  * RSP: Allows disassembling using the RSP instruction set instead of the default one
+* PS2 was added as a new platform option.
+  * When this is selected the R5900 instruction set will be used when disassembling instead of the default one.
+
 ### 0.12.5
 
 * Update minimal spimdisasm version to 1.7.1.
@@ -7,6 +15,7 @@
 * An check was added to prevent segments marked with `exclusive_ram_id` have a vram address range which overlaps with segments not marked with said tag. If this happens it will be warned to the user.
 
 ### 0.12.4
+
 * Fixed a bug involving the order of attributes in symbol_addrs preventing proper range searching during calls to `get_symbol`
 
 ### 0.12.3: Initial Gamecube Support

--- a/segtypes/common/code.py
+++ b/segtypes/common/code.py
@@ -111,6 +111,8 @@ class CommonSegCode(CommonSegGroup):
                     rep.given_symbol_name_format_no_rom = self.symbol_name_format_no_rom
                     rep.sibling = base[1]
                     rep.parent = self
+                    if rep.special_vram_segment:
+                        self.special_vram_segment = True
                     alls.append(rep)
 
                 # Insert alls into segs at i
@@ -267,6 +269,8 @@ class CommonSegCode(CommonSegGroup):
             )
             segment.sibling = base_segments.get(segment.name, None)
             segment.parent = self
+            if segment.special_vram_segment:
+                self.special_vram_segment = True
 
             for i, section in enumerate(self.section_order):
                 if not self.section_boundaries[section].has_start() and dotless_type(

--- a/segtypes/common/codesubsegment.py
+++ b/segtypes/common/codesubsegment.py
@@ -1,6 +1,8 @@
 from typing import Optional
 
 import spimdisasm
+import rabbitizer
+
 from util import options, symbols
 
 from segtypes import segment
@@ -29,6 +31,7 @@ class CommonSegCodeSubsegment(Segment):
         )
 
         self.spim_section: Optional[spimdisasm.mips.sections.SectionBase] = None
+        self.instr_category = rabbitizer.InstrCategory.CPU
 
     @property
     def needs_symbols(self) -> bool:
@@ -56,6 +59,7 @@ class CommonSegCodeSubsegment(Segment):
         )
 
         self.spim_section.isHandwritten = is_hasm
+        self.spim_section.instrCat = self.instr_category
 
         self.spim_section.analyze()
         self.spim_section.setCommentOffset(self.rom_start)

--- a/segtypes/common/codesubsegment.py
+++ b/segtypes/common/codesubsegment.py
@@ -32,6 +32,8 @@ class CommonSegCodeSubsegment(Segment):
 
         self.spim_section: Optional[spimdisasm.mips.sections.SectionBase] = None
         self.instr_category = rabbitizer.InstrCategory.CPU
+        if options.opts.platform == "ps2":
+            self.instr_category = rabbitizer.InstrCategory.R5900
 
     @property
     def needs_symbols(self) -> bool:

--- a/segtypes/common/group.py
+++ b/segtypes/common/group.py
@@ -74,6 +74,8 @@ class CommonSegGroup(CommonSegment):
                 segment_class, subsection_yaml, start, end, vram
             )
             segment.parent = self
+            if segment.special_vram_segment:
+                self.special_vram_segment = True
 
             ret.append(segment)
             prev_start = start

--- a/segtypes/n64/ipl3.py
+++ b/segtypes/n64/ipl3.py
@@ -1,0 +1,9 @@
+from segtypes.common.code import CommonSegCode
+from segtypes.common.hasm import CommonSegHasm
+
+
+class N64SegIpl3(CommonSegHasm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.special_vram_segment = True

--- a/segtypes/n64/rsp.py
+++ b/segtypes/n64/rsp.py
@@ -1,0 +1,10 @@
+import rabbitizer
+
+from segtypes.common.hasm import CommonSegHasm
+
+
+class N64SegRsp(CommonSegHasm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.instr_category = rabbitizer.InstrCategory.RSP

--- a/segtypes/segment.py
+++ b/segtypes/segment.py
@@ -221,6 +221,9 @@ class Segment:
         self.warnings: List[str] = []
         self.did_run = False
 
+        # For segments which are not in the usual VRAM segment space, like N64's IPL3 which lives in 0xA4...
+        self.special_vram_segment: bool = False
+
         if isinstance(self.rom_start, int) and isinstance(self.rom_end, int):
             if self.rom_start > self.rom_end:
                 log.error(

--- a/split.py
+++ b/split.py
@@ -17,7 +17,7 @@ from segtypes.linker_entry import LinkerWriter, to_cname
 from segtypes.segment import RomAddr, Segment
 from util import compiler, log, options, palettes, symbols
 
-VERSION = "0.12.5"
+VERSION = "0.12.6"
 # This value should be keep in sync with the version listed on requirements.txt
 SPIMDISASM_MIN = (1, 7, 1)
 

--- a/util/options.py
+++ b/util/options.py
@@ -254,7 +254,7 @@ def _parse_yaml(
             )
 
     basename = p.parse_opt("basename", str)
-    platform = p.parse_opt_within("platform", str, ["n64", "psx", "gc"])
+    platform = p.parse_opt_within("platform", str, ["n64", "psx", "gc", "ps2"])
     comp = compiler.for_name(p.parse_opt("compiler", str, "IDO"))
 
     base_path = Path(config_paths[0]).parent / p.parse_opt("base_path", str)
@@ -265,7 +265,7 @@ def _parse_yaml(
             "endianness",
             str,
             ["big", "little"],
-            "little" if platform.lower() == "psx" else "big",
+            "little" if platform in ["psx", "ps2"] else "big",
         )
 
         if endianness == "big":

--- a/util/symbols.py
+++ b/util/symbols.py
@@ -208,6 +208,10 @@ def initialize_spim_context(all_segments: "List[Segment]") -> None:
             # We only care about the VRAMs of code segments
             continue
 
+        if segment.special_vram_segment:
+            # Special segments which should not be accounted in the global VRAM calculation, like N64's IPL3
+            continue
+
         if (
             not isinstance(segment.vram_start, int)
             or not isinstance(segment.vram_end, int)


### PR DESCRIPTION
Adds two new N64-specific segments:
- IPL3: Allows setting its correct VRAM address without messing the global segment detection (as suggested by wiseguy)
- RSP: Allows disassembling using the RSP instruction set instead of the default one

Also the PS2 platform was added with very basic support: Setting PS2 as platform in the yaml file will allow using the R5900's instruction set. 
I decided to just add this so people can start messing with PS2 disassemblies