### PR TITLE
Avoid creating unnecesary rodata files for each symbol

### DIFF
--- a/segtypes/common/rodata.py
+++ b/segtypes/common/rodata.py
@@ -49,8 +49,8 @@ class CommonSegRodata(CommonSegData):
 
         if options.opts.migrate_rodata_to_functions:
             if self.spim_section is not None and self.partial_migration:
-                path_folder = options.opts.data_path / self.dir
-                path_folder.parent.mkdir(parents=True, exist_ok=True)
+                path_folder = options.opts.nonmatchings_path / self.dir / self.name
+                path_folder.mkdir(parents=True, exist_ok=True)
 
                 for rodataSym in self.spim_section.symbolList:
                     if not rodataSym.isRdata():

--- a/segtypes/common/rodata.py
+++ b/segtypes/common/rodata.py
@@ -48,9 +48,7 @@ class CommonSegRodata(CommonSegData):
         super().split(rom_bytes)
 
         if options.opts.migrate_rodata_to_functions:
-            if self.spim_section and (
-                not self.type.startswith(".") or self.partial_migration
-            ):
+            if self.spim_section is not None and self.partial_migration:
                 path_folder = options.opts.data_path / self.dir
                 path_folder.parent.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
Some rodata symbols can't be migrated to a function because they may be used by multiple functions so each one of them is exported to its own file which can be included with `INCLUDE_ASM`/`GLOBAL_ASM`.

This behavior only makes sense when doing the `rodata` -> `.rodata` thingy but the file has symbols which can't be migrated, but currently those files are being exported even when not trying to migrate the rodata yet, so it plagues the asm folder with a ton of files. This is addressed by this PR by only doing this when `partial_migration` is `True`

Also, I changed the path of where they are written to so they are put in the same folder where the functions are put (the non_matching folder)