### PR TITLE
Change the jumptable macro, force (not) migration and other misc stuff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # splat Release Notes
 
+### 0.12.7
+
+* Allow setting a different macro for jumptable labels with `asm_jtbl_label_macro`
+  * The currently recommended one is `jlabel` instead of `glabel`
+* Two new options for symbols: `force_migration` and `force_not_migration`
+  * Useful for weird cases where the disassembler decided a rodata symbol must (or must not) be migrated when it really shouldn't (or should)
+* Fix `str_encoding` defaulting to `False` instead of `None`
+* Output empty rules in generated dependency files to avoid issues when the function file does not exist anymore (i.e. when it gets matched)
+* Allow changing the `include_macro_inc` option in the yaml
+
 ### 0.12.6
 
 * Adds two new N64-specific segments:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ tqdm
 intervaltree
 colorama
 # This value should be keep in sync with the version listed on split.py
-spimdisasm>=1.7.1
+spimdisasm>=1.7.11
 rabbitizer>=1.3.1
 pygfxd
 n64img>=0.1.2

--- a/segtypes/common/c.py
+++ b/segtypes/common/c.py
@@ -288,15 +288,15 @@ class CommonSegC(CommonSegCodeSubsegment):
         with dep_path.open("w") as f:
             o_path = build_path / c_path.with_suffix(".o")
             f.write(f"{o_path}:")
-            dependList = []
+            depend_list = []
             for func in self.spim_section.symbolList:
                 func_name = func.getName()
 
                 if func_name in self.global_asm_funcs or is_new_c_file:
                     outpath = asm_out_dir / self.name / (func_name + ".s")
-                    dependList.append(outpath)
+                    depend_list.append(outpath)
                     f.write(f" \\\n    {outpath}")
             f.write("\n")
 
-            for dependFile in dependList:
-                f.write(f"{dependFile}:\n")
+            for depend_file in depend_list:
+                f.write(f"{depend_file}:\n")

--- a/segtypes/common/c.py
+++ b/segtypes/common/c.py
@@ -284,13 +284,19 @@ class CommonSegC(CommonSegCodeSubsegment):
         build_path = options.opts.build_path
 
         dep_path = build_path / c_path.with_suffix(".asmproc.d")
+        dep_path.parent.mkdir(parents=True, exist_ok=True)
         with dep_path.open("w") as f:
             o_path = build_path / c_path.with_suffix(".o")
             f.write(f"{o_path}:")
+            dependList = []
             for func in self.spim_section.symbolList:
                 func_name = func.getName()
 
                 if func_name in self.global_asm_funcs or is_new_c_file:
                     outpath = asm_out_dir / self.name / (func_name + ".s")
+                    dependList.append(outpath)
                     f.write(f" \\\n    {outpath}")
             f.write("\n")
+
+            for dependFile in dependList:
+                f.write(f"{dependFile}:\n")

--- a/segtypes/common/codesubsegment.py
+++ b/segtypes/common/codesubsegment.py
@@ -25,7 +25,7 @@ class CommonSegCodeSubsegment(Segment):
         )
 
         self.str_encoding: Optional[str] = (
-            self.yaml.get("str_encoding", False)
+            self.yaml.get("str_encoding", None)
             if isinstance(self.yaml, dict)
             else None
         )

--- a/segtypes/common/codesubsegment.py
+++ b/segtypes/common/codesubsegment.py
@@ -25,9 +25,7 @@ class CommonSegCodeSubsegment(Segment):
         )
 
         self.str_encoding: Optional[str] = (
-            self.yaml.get("str_encoding", None)
-            if isinstance(self.yaml, dict)
-            else None
+            self.yaml.get("str_encoding", None) if isinstance(self.yaml, dict) else None
         )
 
         self.spim_section: Optional[spimdisasm.mips.sections.SectionBase] = None

--- a/segtypes/common/rodata.py
+++ b/segtypes/common/rodata.py
@@ -53,7 +53,7 @@ class CommonSegRodata(CommonSegData):
                 path_folder.mkdir(parents=True, exist_ok=True)
 
                 for rodataSym in self.spim_section.symbolList:
-                    if not rodataSym.isRdata():
+                    if rodataSym.shouldMigrate():
                         continue
 
                     path = path_folder / f"{rodataSym.getName()}.s"

--- a/segtypes/common/rodata.py
+++ b/segtypes/common/rodata.py
@@ -58,7 +58,7 @@ class CommonSegRodata(CommonSegData):
 
                     path = path_folder / f"{rodataSym.getName()}.s"
                     with open(path, "w", newline="\n") as f:
-                        if options.opts.compiler.include_macro_inc:
+                        if options.opts.include_macro_inc:
                             f.write('.include "macro.inc"\n\n')
                         preamble = options.opts.generated_s_preamble
                         if preamble:

--- a/split.py
+++ b/split.py
@@ -17,9 +17,9 @@ from segtypes.linker_entry import LinkerWriter, to_cname
 from segtypes.segment import RomAddr, Segment
 from util import compiler, log, options, palettes, symbols
 
-VERSION = "0.12.6"
+VERSION = "0.12.7"
 # This value should be keep in sync with the version listed on requirements.txt
-SPIMDISASM_MIN = (1, 7, 1)
+SPIMDISASM_MIN = (1, 7, 11)
 
 parser = argparse.ArgumentParser(
     description="Split a rom given a rom, a config, and output directory"
@@ -29,6 +29,9 @@ parser.add_argument("--modes", nargs="+", default="all")
 parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
 parser.add_argument(
     "--use-cache", action="store_true", help="Only split changed segments in config"
+)
+parser.add_argument(
+    "--skip-version-check", action="store_true", help="Skips the disassembler's version check"
 )
 
 linker_writer: LinkerWriter
@@ -258,10 +261,10 @@ def brief_seg_name(seg: Segment, limit: int, ellipsis="…") -> str:
     return s
 
 
-def main(config_path, modes, verbose, use_cache=True):
+def main(config_path, modes, verbose, use_cache=True, skip_version_check=False):
     global config
 
-    if spimdisasm.__version_info__ < SPIMDISASM_MIN:
+    if not skip_version_check and spimdisasm.__version_info__ < SPIMDISASM_MIN:
         log.error(
             f"splat {VERSION} requires as minimum spimdisasm {SPIMDISASM_MIN}, but the installed version is {spimdisasm.__version_info__}"
         )
@@ -505,4 +508,4 @@ def main(config_path, modes, verbose, use_cache=True):
 
 if __name__ == "__main__":
     args = parser.parse_args()
-    main(args.config, args.modes, args.verbose, args.use_cache)
+    main(args.config, args.modes, args.verbose, args.use_cache, args.skip_version_check)

--- a/split.py
+++ b/split.py
@@ -31,7 +31,9 @@ parser.add_argument(
     "--use-cache", action="store_true", help="Only split changed segments in config"
 )
 parser.add_argument(
-    "--skip-version-check", action="store_true", help="Skips the disassembler's version check"
+    "--skip-version-check",
+    action="store_true",
+    help="Skips the disassembler's version check",
 )
 
 linker_writer: LinkerWriter

--- a/split.py
+++ b/split.py
@@ -241,6 +241,7 @@ def configure_disassembler():
     spimdisasm.common.GlobalConfig.GP_VALUE = options.opts.gp
 
     spimdisasm.common.GlobalConfig.ASM_TEXT_LABEL = options.opts.asm_function_macro
+    spimdisasm.common.GlobalConfig.ASM_JTBL_LABEL = options.opts.asm_jtbl_label_macro
     spimdisasm.common.GlobalConfig.ASM_DATA_LABEL = options.opts.asm_data_macro
     spimdisasm.common.GlobalConfig.ASM_TEXT_END_LABEL = options.opts.asm_end_label
 

--- a/util/compiler.py
+++ b/util/compiler.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 class Compiler:
     name: str
     asm_function_macro: str = "glabel"
+    asm_jtbl_label_macro: str = "glabel"
     asm_data_macro: str = "glabel"
     asm_end_label: str = ""
     c_newline: str = "\n"
@@ -20,6 +21,7 @@ GCC = Compiler(
 SN64 = Compiler(
     "SN64",
     asm_function_macro=".globl",
+    asm_jtbl_label_macro=".globl",
     asm_data_macro=".globl",
     asm_end_label=".end",
     c_newline="\r\n",

--- a/util/options.py
+++ b/util/options.py
@@ -131,6 +131,8 @@ class SplatOpts:
     asm_data_macro: str
     # Determines the macro used at the end of a function, such as endlabel or .end
     asm_end_label: str
+    # Determines including the macro.inc file on non-migrated rodata variables
+    include_macro_inc: bool
     # Determines the number of characters to left align before the TODO finish documenting
     mnemonic_ljust: int
     # Determines whether to pad the rom address
@@ -351,6 +353,7 @@ def _parse_yaml(
         asm_jtbl_label_macro=p.parse_opt("asm_jtbl_label_macro", str, comp.asm_jtbl_label_macro),
         asm_data_macro=p.parse_opt("asm_data_macro", str, comp.asm_data_macro),
         asm_end_label=p.parse_opt("asm_end_label", str, comp.asm_end_label),
+        include_macro_inc=p.parse_opt("include_macro_inc", bool, comp.include_macro_inc),
         mnemonic_ljust=p.parse_opt("mnemonic_ljust", int, 11),
         rom_address_padding=p.parse_opt("rom_address_padding", bool, False),
         mips_abi_gpr=p.parse_opt_within(

--- a/util/options.py
+++ b/util/options.py
@@ -125,6 +125,8 @@ class SplatOpts:
     asm_inc_header: str
     # Determines the macro used to declare functions in asm files
     asm_function_macro: str
+    # Determines the macro used to declare jumptable labels in asm files
+    asm_jtbl_label_macro: str
     # Determines the macro used to declare data symbols in asm files
     asm_data_macro: str
     # Determines the macro used at the end of a function, such as endlabel or .end
@@ -346,6 +348,7 @@ def _parse_yaml(
         asm_function_macro=p.parse_opt(
             "asm_function_macro", str, comp.asm_function_macro
         ),
+        asm_jtbl_label_macro=p.parse_opt("asm_jtbl_label_macro", str, comp.asm_jtbl_label_macro),
         asm_data_macro=p.parse_opt("asm_data_macro", str, comp.asm_data_macro),
         asm_end_label=p.parse_opt("asm_end_label", str, comp.asm_end_label),
         mnemonic_ljust=p.parse_opt("mnemonic_ljust", int, 11),

--- a/util/options.py
+++ b/util/options.py
@@ -350,10 +350,14 @@ def _parse_yaml(
         asm_function_macro=p.parse_opt(
             "asm_function_macro", str, comp.asm_function_macro
         ),
-        asm_jtbl_label_macro=p.parse_opt("asm_jtbl_label_macro", str, comp.asm_jtbl_label_macro),
+        asm_jtbl_label_macro=p.parse_opt(
+            "asm_jtbl_label_macro", str, comp.asm_jtbl_label_macro
+        ),
         asm_data_macro=p.parse_opt("asm_data_macro", str, comp.asm_data_macro),
         asm_end_label=p.parse_opt("asm_end_label", str, comp.asm_end_label),
-        include_macro_inc=p.parse_opt("include_macro_inc", bool, comp.include_macro_inc),
+        include_macro_inc=p.parse_opt(
+            "include_macro_inc", bool, comp.include_macro_inc
+        ),
         mnemonic_ljust=p.parse_opt("mnemonic_ljust", int, 11),
         rom_address_padding=p.parse_opt("rom_address_padding", bool, False),
         mips_abi_gpr=p.parse_opt_within(

--- a/util/symbols.py
+++ b/util/symbols.py
@@ -180,6 +180,12 @@ def initialize(all_segments: "List[Segment]"):
                                         if attr_name == "ignore":
                                             ignore_sym = tf_val
                                             continue
+                                        if attr_name == "force_migration":
+                                            sym.force_migration = tf_val
+                                            continue
+                                        if attr_name == "force_not_migration":
+                                            sym.force_not_migration = tf_val
+                                            continue
                         if ignore_sym:
                             ignored_addresses.add(sym.vram_start)
                             ignore_sym = False
@@ -330,6 +336,10 @@ def add_symbol_to_spim_segment(
         context_sym.vromAddress = sym.rom
     if sym.given_size is not None:
         context_sym.size = sym.size
+    if sym.force_migration:
+        context_sym.forceMigration = True
+    if sym.force_not_migration:
+        context_sym.forceNotMigration = True
     context_sym.setNameGetCallbackIfUnset(lambda _: sym.name)
 
     return context_sym
@@ -369,6 +379,10 @@ def add_symbol_to_spim_section(
         context_sym.vromAddress = sym.rom
     if sym.given_size is not None:
         context_sym.size = sym.size
+    if sym.force_migration:
+        context_sym.forceMigration = True
+    if sym.force_not_migration:
+        context_sym.forceNotMigration = True
     context_sym.setNameGetCallbackIfUnset(lambda _: sym.name)
 
     return context_sym
@@ -451,6 +465,9 @@ class Symbol:
     dead: bool = False
     extract: bool = True
     user_declared: bool = False
+
+    force_migration: bool = False
+    force_not_migration: bool = False
 
     _generated_default_name: Optional[str] = None
     _last_type: Optional[str] = None


### PR DESCRIPTION
- Allow setting a different macro for jumptable labels with `asm_jtbl_label_macro`
  - The currently recommended one is `jlabel` instead of `glabel`
- Two new options for symbols: `force_migration` and `force_not_migration`
  - Useful for weird cases where the disassembler decided a rodata symbol must (or must not) be migrated when it really shouldn't (or should)
- Fix `str_encoding` defaulting to `False` instead of `None`
- Output empty rules in generated dependency files to avoid issues when the function file does not exist anymore (i.e. when it gets matched)
- Allow changing the `include_macro_inc` option in the yaml