### PR TITLE
Use `.L` as prefix for jtbl labels

### DIFF
--- a/util/symbols.py
+++ b/util/symbols.py
@@ -526,9 +526,7 @@ class Symbol:
             prefix = "func"
         elif self.type == "jtbl":
             prefix = "jtbl"
-        elif self.type == "jtbl_label":
-            return f"L{suffix}"
-        elif self.type == "label":
+        elif self.type in {"jtbl_label", "label"}:
             return f".L{suffix}"
         else:
             prefix = "D"


### PR DESCRIPTION
For some reason using `LXXXXXXXX` labels for jumptable labels messes with asm differ, preventing using it at any function with jumptables, at least on gcc kmc. Using `.LXXXXXXXX` (with a dot prefix) seems to fix this issue.

As a reference, this is the traceback of asm differ:
```
Traceback (most recent call last):
  File "/home/angie/Documents/n64decomp/drmario64/./diff.py", line 3359, in <module>
    main()
  File "/home/angie/Documents/n64decomp/drmario64/./diff.py", line 3304, in main
    display = Display(basedump, mydump, config)
  File "/home/angie/Documents/n64decomp/drmario64/./diff.py", line 3130, in __init__
    self.base_lines = process(basedump, config)
  File "/home/angie/Documents/n64decomp/drmario64/./diff.py", line 2255, in process
    original, reloc_symbol = processor.process_reloc(reloc_row, original)
  File "/home/angie/Documents/n64decomp/drmario64/./diff.py", line 1491, in process_reloc
    repl = row.split()[-1] + reloc_addend_from_imm(imm, before, self.config.arch)
  File "/home/angie/Documents/n64decomp/drmario64/./diff.py", line 2095, in reloc_addend_from_imm
    mnemonic = before.split()[0]
IndexError: list index out of range

```
