### PR TITLE
Add i1 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ colorama
 spimdisasm>=1.7.11
 rabbitizer>=1.3.1
 pygfxd
-n64img>=0.1.3
+n64img>=0.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ colorama
 spimdisasm>=1.7.11
 rabbitizer>=1.3.1
 pygfxd
-n64img>=0.1.2
+n64img>=0.1.3

--- a/segtypes/n64/i1.py
+++ b/segtypes/n64/i1.py
@@ -5,5 +5,5 @@ from segtypes.n64.img import N64SegImg
 
 class N64SegI1(N64SegImg):
     def __init__(self, *args, **kwargs):
-        kwargs["img_cls"] = n64img.image.IA1
+        kwargs["img_cls"] = n64img.image.I1
         super().__init__(*args, **kwargs)

--- a/segtypes/n64/i1.py
+++ b/segtypes/n64/i1.py
@@ -3,7 +3,7 @@ import n64img.image
 from segtypes.n64.img import N64SegImg
 
 
-class N64SegIa1(N64SegImg):
+class N64SegI1(N64SegImg):
     def __init__(self, *args, **kwargs):
         kwargs["img_cls"] = n64img.image.IA1
         super().__init__(*args, **kwargs)

--- a/segtypes/n64/ia1.py
+++ b/segtypes/n64/ia1.py
@@ -1,0 +1,9 @@
+import n64img.image
+
+from segtypes.n64.img import N64SegImg
+
+
+class N64SegIa1(N64SegImg):
+    def __init__(self, *args, **kwargs):
+        kwargs["img_cls"] = n64img.image.IA1
+        super().__init__(*args, **kwargs)


### PR DESCRIPTION
This PR pending changes to n64img.

I believe the definition for ia4 in n64img needs to be duplicated and renamed to ia1. Then change the final arithmetic from `// 2` to `// 8`

There may also be a bug with n64img not supporting 13x14 textures (which is the boot font)

This would be a nice have for mk64 as it uses this file type for the crash screen font.