### PR TITLE
User-defined relocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 0.12.10
 
 - Allows passing user-created relocs to the disassembler via the `reloc_addrs.txt` file, allowing to improve the automatic disassembly.
+- Multiple reloc_addrs files can be specified in the yaml with the `reloc_addrs_path` option.
 
 ### 0.12.9
 * Added `format_sym_name()` to the vtx segment so it, too, can be extended

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # splat Release Notes
 
+### 0.12.10
+
+- Allows passing user-created relocs to the disassembler via the `reloc_addrs.txt` file, allowing to improve the automatic disassembly.
+
 ### 0.12.9
 * Added `format_sym_name()` to the vtx segment so it, too, can be extended
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ tqdm
 intervaltree
 colorama
 # This value should be keep in sync with the version listed on split.py
-spimdisasm>=1.8.2
+spimdisasm>=1.9.0
 rabbitizer>=1.4.0
 pygfxd
 n64img>=0.1.4

--- a/split.py
+++ b/split.py
@@ -15,7 +15,7 @@ from intervaltree import Interval, IntervalTree
 
 from segtypes.linker_entry import LinkerWriter, to_cname
 from segtypes.segment import Segment
-from util import compiler, log, options, palettes, symbols
+from util import compiler, log, options, palettes, symbols, relocs
 
 VERSION = "0.12.9"
 # This value should be keep in sync with the version listed on requirements.txt
@@ -226,18 +226,18 @@ def configure_disassembler():
 
     rabbitizer.config.pseudos_pseudoMove = False
 
-    selectedCompiler = options.opts.compiler
-    if selectedCompiler == compiler.SN64:
+    selected_compiler = options.opts.compiler
+    if selected_compiler == compiler.SN64:
         rabbitizer.config.regNames_namedRegisters = False
         rabbitizer.config.toolchainTweaks_sn64DivFix = True
         rabbitizer.config.toolchainTweaks_treatJAsUnconditionalBranch = True
         spimdisasm.common.GlobalConfig.ASM_COMMENT = False
         spimdisasm.common.GlobalConfig.SYMBOL_FINDER_FILTERED_ADDRESSES_AS_HILO = False
         spimdisasm.common.GlobalConfig.COMPILER = spimdisasm.common.Compiler.SN64
-    elif selectedCompiler == compiler.GCC:
+    elif selected_compiler == compiler.GCC:
         rabbitizer.config.toolchainTweaks_treatJAsUnconditionalBranch = True
         spimdisasm.common.GlobalConfig.COMPILER = spimdisasm.common.Compiler.GCC
-    elif selectedCompiler == compiler.IDO:
+    elif selected_compiler == compiler.IDO:
         spimdisasm.common.GlobalConfig.COMPILER = spimdisasm.common.Compiler.IDO
 
     spimdisasm.common.GlobalConfig.GP_VALUE = options.opts.gp
@@ -334,12 +334,14 @@ def main(config_path, modes, verbose, use_cache=True, skip_version_check=False):
 
     # Load and process symbols
     symbols.initialize(all_segments)
+    relocs.initialize()
 
     # Assign symbols to segments
     assign_symbols_to_segments()
 
     if options.opts.is_mode_active("code"):
         symbols.initialize_spim_context(all_segments)
+        relocs.initialize_spim_context()
 
     # Resolve raster/palette siblings
     if options.opts.is_mode_active("img"):

--- a/split.py
+++ b/split.py
@@ -17,9 +17,9 @@ from segtypes.linker_entry import LinkerWriter, to_cname
 from segtypes.segment import Segment
 from util import compiler, log, options, palettes, symbols, relocs
 
-VERSION = "0.12.9"
+VERSION = "0.12.10"
 # This value should be keep in sync with the version listed on requirements.txt
-SPIMDISASM_MIN = (1, 7, 11)
+SPIMDISASM_MIN = (1, 9, 0)
 
 parser = argparse.ArgumentParser(
     description="Split a rom given a rom, a config, and output directory"

--- a/util/options.py
+++ b/util/options.py
@@ -45,6 +45,7 @@ class SplatOpts:
     #
     # It's possible to use more than one file by supplying a list instead of a string
     symbol_addrs_paths: List[Path]
+    reloc_addrs_paths: List[Path]
     # Determines the path to the project build directory
     build_path: Path
     # Determines the path to the source code directory
@@ -257,6 +258,18 @@ def _parse_yaml(
                 f"Expected str or list for 'symbol_addrs_paths', got {type(paths)}"
             )
 
+    def parse_reloc_addrs_paths(base_path: Path) -> List[Path]:
+        paths = p.parse_opt("reloc_addrs_path", object, "reloc_addrs.txt")
+
+        if isinstance(paths, str):
+            return [base_path / paths]
+        elif isinstance(paths, list):
+            return [base_path / path for path in paths]
+        else:
+            raise ValueError(
+                f"Expected str or list for 'reloc_addrs_path', got {type(paths)}"
+            )
+
     basename = p.parse_opt("basename", str)
     platform = p.parse_opt_within("platform", str, ["n64", "psx", "gc", "ps2"])
     comp = compiler.for_name(p.parse_opt("compiler", str, "IDO"))
@@ -299,6 +312,7 @@ def _parse_yaml(
         gp=p.parse_opt("gp_value", int, 0),
         asset_path=p.parse_path(base_path, "asset_path", "assets"),
         symbol_addrs_paths=parse_symbol_addrs_paths(base_path),
+        reloc_addrs_paths=parse_reloc_addrs_paths(base_path),
         build_path=p.parse_path(base_path, "build_path", "build"),
         src_path=p.parse_path(base_path, "src_path", "src"),
         asm_path=asm_path,

--- a/util/options.py
+++ b/util/options.py
@@ -240,9 +240,7 @@ class OptParser:
         elif isinstance(paths, list):
             return [base_path / path for path in paths]
         else:
-            raise ValueError(
-                f"Expected str or list for '{opt}', got {type(paths)}"
-            )
+            raise ValueError(f"Expected str or list for '{opt}', got {type(paths)}")
 
     def check_no_unread_opts(self) -> None:
         opts = [opt for opt in self._yaml if opt not in self._read_opts]
@@ -299,8 +297,12 @@ def _parse_yaml(
         use_o_as_suffix=p.parse_opt("o_as_suffix", bool, False),
         gp=p.parse_opt("gp_value", int, 0),
         asset_path=p.parse_path(base_path, "asset_path", "assets"),
-        symbol_addrs_paths=p.parse_path_list(base_path, "symbol_addrs_path", "symbol_addrs.txt"),
-        reloc_addrs_paths=p.parse_path_list(base_path, "reloc_addrs_path", "reloc_addrs.txt"),
+        symbol_addrs_paths=p.parse_path_list(
+            base_path, "symbol_addrs_path", "symbol_addrs.txt"
+        ),
+        reloc_addrs_paths=p.parse_path_list(
+            base_path, "reloc_addrs_path", "reloc_addrs.txt"
+        ),
         build_path=p.parse_path(base_path, "build_path", "build"),
         src_path=p.parse_path(base_path, "src_path", "src"),
         asm_path=asm_path,

--- a/util/options.py
+++ b/util/options.py
@@ -232,6 +232,18 @@ class OptParser:
             return None
         return self.parse_path(base_path, opt)
 
+    def parse_path_list(self, base_path: Path, opt: str, default: str) -> List[Path]:
+        paths = self.parse_opt(opt, object, default)
+
+        if isinstance(paths, str):
+            return [base_path / paths]
+        elif isinstance(paths, list):
+            return [base_path / path for path in paths]
+        else:
+            raise ValueError(
+                f"Expected str or list for '{opt}', got {type(paths)}"
+            )
+
     def check_no_unread_opts(self) -> None:
         opts = [opt for opt in self._yaml if opt not in self._read_opts]
         if opts:
@@ -245,30 +257,6 @@ def _parse_yaml(
     verbose: bool = False,
 ) -> SplatOpts:
     p = OptParser(yaml)
-
-    def parse_symbol_addrs_paths(base_path: Path) -> List[Path]:
-        paths = p.parse_opt("symbol_addrs_path", object, "symbol_addrs.txt")
-
-        if isinstance(paths, str):
-            return [base_path / paths]
-        elif isinstance(paths, list):
-            return [base_path / path for path in paths]
-        else:
-            raise ValueError(
-                f"Expected str or list for 'symbol_addrs_paths', got {type(paths)}"
-            )
-
-    def parse_reloc_addrs_paths(base_path: Path) -> List[Path]:
-        paths = p.parse_opt("reloc_addrs_path", object, "reloc_addrs.txt")
-
-        if isinstance(paths, str):
-            return [base_path / paths]
-        elif isinstance(paths, list):
-            return [base_path / path for path in paths]
-        else:
-            raise ValueError(
-                f"Expected str or list for 'reloc_addrs_path', got {type(paths)}"
-            )
 
     basename = p.parse_opt("basename", str)
     platform = p.parse_opt_within("platform", str, ["n64", "psx", "gc", "ps2"])
@@ -311,8 +299,8 @@ def _parse_yaml(
         use_o_as_suffix=p.parse_opt("o_as_suffix", bool, False),
         gp=p.parse_opt("gp_value", int, 0),
         asset_path=p.parse_path(base_path, "asset_path", "assets"),
-        symbol_addrs_paths=parse_symbol_addrs_paths(base_path),
-        reloc_addrs_paths=parse_reloc_addrs_paths(base_path),
+        symbol_addrs_paths=p.parse_path_list(base_path, "symbol_addrs_path", "symbol_addrs.txt"),
+        reloc_addrs_paths=p.parse_path_list(base_path, "reloc_addrs_path", "reloc_addrs.txt"),
         build_path=p.parse_path(base_path, "build_path", "build"),
         src_path=p.parse_path(base_path, "src_path", "src"),
         asm_path=asm_path,

--- a/util/relocs.py
+++ b/util/relocs.py
@@ -1,0 +1,112 @@
+from dataclasses import dataclass
+from typing import Dict
+
+import spimdisasm
+import tqdm
+from intervaltree import Interval, IntervalTree
+
+from util import log, options, symbols
+
+@dataclass
+class Reloc:
+    rom_address: int
+    reloc_type: str
+    symbol_name: str
+
+    addend: int = 0
+
+all_relocs: Dict[int, Reloc] = {}
+
+def add_reloc(reloc: Reloc):
+    all_relocs[reloc.rom_address] = reloc
+
+def initialize():
+    global all_relocs
+
+    all_relocs = {}
+
+    for path in options.opts.reloc_addrs_paths:
+        if not path.exists():
+            continue
+
+        with path.open() as f:
+            sym_addrs_lines = f.readlines()
+        for line_num, line in enumerate(
+            tqdm.tqdm(sym_addrs_lines, desc=f"Loading relocs ({path.stem})")
+        ):
+            line = line.strip()
+            # Allow comments
+            line = line.split("//")[0]
+            line = line.strip()
+
+            if line == "":
+                continue
+
+            rom_addr = None
+            reloc_type = None
+            symbol_name = None
+            addend = None
+
+            for info in line.split(" "):
+                if ":" not in info:
+                    continue
+
+                if info.count(":") > 1:
+                    log.parsing_error_preamble(path, line_num, line)
+                    log.write(f"Too many ':'s in '{info}'")
+                    log.error("")
+
+                attr_name, attr_val = info.split(":")
+                if attr_name == "":
+                    log.parsing_error_preamble(path, line_num, line)
+                    log.write(
+                        f"Missing attribute name in '{info}', is there extra whitespace?"
+                    )
+                    log.error("")
+                if attr_val == "":
+                    log.parsing_error_preamble(path, line_num, line)
+                    log.write(
+                        f"Missing attribute value in '{info}', is there extra whitespace?"
+                    )
+                    log.error("")
+
+                # Non-Boolean attributes
+                try:
+                    if attr_name == "rom":
+                        rom_addr = int(attr_val, 0)
+                        continue
+                    if attr_name == "reloc":
+                        reloc_type = attr_val
+                        continue
+                    if attr_name == "symbol":
+                        symbol_name = attr_val
+                        continue
+                    if attr_name == "addend":
+                        addend = int(attr_val, 0)
+                        continue
+                except:
+                    log.parsing_error_preamble(path, line_num, line)
+                    log.write(
+                        f"value of attribute '{attr_name}' could not be read:"
+                    )
+                    log.write("")
+                    raise
+
+            if rom_addr is None or reloc_type is None or symbol_name is None:
+                log.parsing_error_preamble(path, line_num, line)
+                log.error("")
+
+            reloc = Reloc(rom_addr, reloc_type, symbol_name)
+            if addend is not None:
+                reloc.addend = addend
+
+            add_reloc(reloc)
+
+def initialize_spim_context():
+    for rom_address, reloc in all_relocs.items():
+        reloc_type = spimdisasm.common.RelocType.fromStr(reloc.reloc_type)
+
+        if reloc_type is None:
+            log.error(f"Reloc type '{reloc.reloc_type}' is not valid. Rom address: 0x{rom_address:X}")
+
+        symbols.spim_context.addGlobalReloc(rom_address, reloc_type, reloc.symbol_name, addend=reloc.addend)

--- a/util/symbols.py
+++ b/util/symbols.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional, Set, TYPE_CHECKING
 
 import spimdisasm
 import tqdm
-from intervaltree import Interval, IntervalTree
+from intervaltree import IntervalTree
 
 # circular import
 if TYPE_CHECKING:


### PR DESCRIPTION
Adds the ability to provide user-defined relocs to the disassembler. This can be useful to improve automatic disassembly, use negative addends which aren't used by default by the disassembler or use different symbols which happen to have the same vram.

The user can pass those relocs using the `reloc_addrs.txt` file. This file has the following format:
```
rom:ROMADDR symbol:SYMBOLNAME reloc:RELOCTYPE
```
Where
- `ROMADDR` is the rom address of the instruction which the user want to change, it must be either decimal or hex with a leading 0x.
- `SYMBOLNAME` is the symbol to use.
- `RELOCTYPE` is the relocation type to use. It must be a valid relocation type. The most common ones are `MIPS_HI16`, `MIPS_LO16` and `MIPS_26`. A list can be seen [here](https://github.com/Decompollaborate/spimdisasm/blob/a2c13446b2881bec1f86d7f245d73475786b3c56/spimdisasm/common/Relocation.py#L15)
- Additionally an optional `addend` value is valid too. It can be either a positive or negative value and it can be either dec or hex

Multiple reloc_addrs files can be specified in the yaml with the `reloc_addrs_path` option.

Finally the minimal spimdisasm version has been bumped to `1.9.0`