### PR TITLE
Addends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,24 @@
 # splat Release Notes
 
+### 0.12.11
+
+* New disassembly option in the yaml: `allow_data_addends`.
+  * Allows enabling/disabling using addends on all `.data` symbols.
+* Three new options for symbols: `name_end`, `allow_addend` and `dont_allow_addend`.
+  * `name_end`: allows to provide a closing name for any symbol. Useful for handwritten asm which usually have an "end" name.
+  * `allow_addend` and `dont_allow_addend`: Allow overriding the global `allow_data_addends` option for allowing addends on data symbols.
+
 ### 0.12.10
 
-- Allows passing user-created relocs to the disassembler via the `reloc_addrs.txt` file, allowing to improve the automatic disassembly.
-- Multiple reloc_addrs files can be specified in the yaml with the `reloc_addrs_path` option.
+* Allows passing user-created relocs to the disassembler via the `reloc_addrs.txt` file, allowing to improve the automatic disassembly.
+* Multiple reloc_addrs files can be specified in the yaml with the `reloc_addrs_path` option.
 
 ### 0.12.9
+
 * Added `format_sym_name()` to the vtx segment so it, too, can be extended
 
 ### 0.12.8
+
 * The gfx and vtx segments now have a `data_only` option, which, if enabled, will emit only the plain data for the type and omit the enclosing symbol definition. This mode is useful when you want to manually declare the symbol and then #include the extracted data within the declaration.
 * The gfx segment has a method, `format_sym_name()`, which will allow custom overriding of the output of symbol names by extending the `gfx` segment. For example, this can be used to transform context-specific symbol names like mac_01_vtx into N(vtx), where N() is a macro that applies the current "namespace" to the symbol. Paper Mario plans to use this so we can extract an asset once and then #include it in multiple places, while giving each inclusion unique symbol names for each component.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ tqdm
 intervaltree
 colorama
 # This value should be keep in sync with the version listed on split.py
-spimdisasm>=1.9.0
+spimdisasm>=1.10.0
 rabbitizer>=1.4.0
 pygfxd
 n64img>=0.1.4

--- a/split.py
+++ b/split.py
@@ -256,7 +256,9 @@ def configure_disassembler():
 
     spimdisasm.common.GlobalConfig.LINE_ENDS = options.opts.c_newline
 
-    spimdisasm.common.GlobalConfig.ALLOW_ALL_ADDENDS_ON_DATA = options.opts.allow_data_addends
+    spimdisasm.common.GlobalConfig.ALLOW_ALL_ADDENDS_ON_DATA = (
+        options.opts.allow_data_addends
+    )
 
 
 def brief_seg_name(seg: Segment, limit: int, ellipsis="…") -> str:

--- a/split.py
+++ b/split.py
@@ -17,9 +17,9 @@ from segtypes.linker_entry import LinkerWriter, to_cname
 from segtypes.segment import Segment
 from util import compiler, log, options, palettes, symbols, relocs
 
-VERSION = "0.12.10"
+VERSION = "0.12.11"
 # This value should be keep in sync with the version listed on requirements.txt
-SPIMDISASM_MIN = (1, 9, 0)
+SPIMDISASM_MIN = (1, 10, 0)
 
 parser = argparse.ArgumentParser(
     description="Split a rom given a rom, a config, and output directory"
@@ -255,6 +255,8 @@ def configure_disassembler():
         spimdisasm.common.GlobalConfig.ASM_DATA_SYM_AS_LABEL = True
 
     spimdisasm.common.GlobalConfig.LINE_ENDS = options.opts.c_newline
+
+    spimdisasm.common.GlobalConfig.ALLOW_ALL_ADDENDS_ON_DATA = options.opts.allow_data_addends
 
 
 def brief_seg_name(seg: Segment, limit: int, ellipsis="…") -> str:

--- a/util/options.py
+++ b/util/options.py
@@ -151,6 +151,8 @@ class SplatOpts:
     create_asm_dependencies: bool
     # Global option for rodata string encoding. This can be overriden per segment
     string_encoding: Optional[str]
+    # Global option for allowing data symbols using addends on symbol references. It can be overriden per symbol
+    allow_data_addends: bool
 
     ################################################################################
     # N64-specific options
@@ -379,6 +381,7 @@ def _parse_yaml(
         add_set_gp_64=p.parse_opt("add_set_gp_64", bool, True),
         create_asm_dependencies=p.parse_opt("create_asm_dependencies", bool, False),
         string_encoding=p.parse_optional_opt("string_encoding", str),
+        allow_data_addends=p.parse_opt("allow_data_addends", bool, True),
         header_encoding=p.parse_opt("header_encoding", str, "ASCII"),
         gfx_ucode=p.parse_opt_within(
             "gfx_ucode",

--- a/util/symbols.py
+++ b/util/symbols.py
@@ -186,6 +186,12 @@ def initialize(all_segments: "List[Segment]"):
                                         if attr_name == "force_not_migration":
                                             sym.force_not_migration = tf_val
                                             continue
+                                        if attr_name == "allow_addend":
+                                            sym.allow_addend = tf_val
+                                            continue
+                                        if attr_name == "dont_allow_addend":
+                                            sym.dont_allow_addend = tf_val
+                                            continue
                         if ignore_sym:
                             if sym.given_size == None or sym.given_size == 0:
                                 ignored_addresses.add(sym.vram_start)
@@ -346,6 +352,10 @@ def add_symbol_to_spim_segment(
         context_sym.forceMigration = True
     if sym.force_not_migration:
         context_sym.forceNotMigration = True
+    if sym.allow_addend:
+        context_sym.allowedToReferenceAddends = True
+    if sym.dont_allow_addend:
+        context_sym.notAllowedToReferenceAddends = True
     context_sym.setNameGetCallbackIfUnset(lambda _: sym.name)
 
     return context_sym
@@ -474,6 +484,9 @@ class Symbol:
 
     force_migration: bool = False
     force_not_migration: bool = False
+
+    allow_addend: bool = False
+    dont_allow_addend: bool = False
 
     _generated_default_name: Optional[str] = None
     _last_type: Optional[str] = None

--- a/util/symbols.py
+++ b/util/symbols.py
@@ -144,6 +144,9 @@ def initialize(all_segments: "List[Segment]"):
                                                 # Add segment to symbol
                                                 sym.segment = seg
                                             continue
+                                        if attr_name == "name_end":
+                                            sym.given_name_end = attr_val
+                                            continue
                                     except:
                                         log.parsing_error_preamble(path, line_num, line)
                                         log.write(
@@ -357,6 +360,8 @@ def add_symbol_to_spim_segment(
     if sym.dont_allow_addend:
         context_sym.notAllowedToReferenceAddends = True
     context_sym.setNameGetCallbackIfUnset(lambda _: sym.name)
+    if sym.given_name_end:
+        context_sym.nameEnd = sym.given_name_end
 
     return context_sym
 
@@ -400,6 +405,8 @@ def add_symbol_to_spim_section(
     if sym.force_not_migration:
         context_sym.forceNotMigration = True
     context_sym.setNameGetCallbackIfUnset(lambda _: sym.name)
+    if sym.given_name_end:
+        context_sym.nameEnd = sym.given_name_end
 
     return context_sym
 
@@ -471,6 +478,7 @@ class Symbol:
     vram_start: int
 
     given_name: Optional[str] = None
+    given_name_end: Optional[str] = None
     rom: Optional[int] = None
     type: Optional[str] = None
     given_size: Optional[int] = None


### PR DESCRIPTION
* New disassembly option in the yaml: `allow_data_addends`.
  * Allows enabling/disabling using addends on all `.data` symbols.
* Three new options for symbols: `name_end`, `allow_addend` and `dont_allow_addend`.
  * `name_end`: allows to provide a closing name for any symbol. Useful for handwritten asm which usually have an "end" name.
  * `allow_addend` and `dont_allow_addend`: Allow overriding the global `allow_data_addends` option for allowing addends on data symbols.
