### PR TITLE
Warn if migrated rodata symbols have gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # splat Release Notes
 
+### 0.12.12
+
+* Try to detect and warn to the user if a gap between two migrated rodata symbols is detected and suggest possible solutions to the user.
+
 ### 0.12.11
 
 * New disassembly option in the yaml: `allow_data_addends`.

--- a/segtypes/common/c.py
+++ b/segtypes/common/c.py
@@ -157,6 +157,17 @@ class CommonSegC(CommonSegCodeSubsegment):
 
         return ret
 
+    def check_gaps_in_migrated_rodata(self, func: spimdisasm.mips.symbols.SymbolFunction, rodata_list: list[spimdisasm.mips.symbols.SymbolBase]):
+        for index in range(len(rodata_list)-1):
+            rodata_sym = rodata_list[index]
+            next_rodata_sym = rodata_list[index+1]
+
+            if rodata_sym.vramEnd != next_rodata_sym.vram:
+                log.write(f"\nA gap was detected in migrated rodata symbols!", status="warn")
+                log.write(f"\t In function '{func.getName()}' (0x{func.vram:08X}), gap detected between '{rodata_sym.getName()}' (0x{rodata_sym.vram:08X}) and '{next_rodata_sym.getName()}' (0x{next_rodata_sym.vram:08X})")
+                log.write(f"\t The address of the missing rodata symbol is 0x{rodata_sym.vramEnd:08X}.")
+                log.write(f"\t Try to force the migration of that symbol with `force_migration:True` in the symbol_addrs.txt file; or avoid the migration of symbols around this address with `force:not_migration:True`")
+
     def create_c_asm_file(
         self,
         func: spimdisasm.mips.symbols.SymbolFunction,
@@ -186,8 +197,8 @@ class CommonSegC(CommonSegCodeSubsegment):
                     func_rodata = list({s for s in self.parent.rodata_syms[func.vram]})
                     func_rodata.sort(key=lambda s: s.vram_start)
 
-                    rdata_list = []
-                    late_rodata_list = []
+                    rdata_list: list[spimdisasm.mips.symbols.SymbolBase] = []
+                    late_rodata_list: list[spimdisasm.mips.symbols.SymbolBase] = []
                     late_rodata_size = 0
 
                     processed_rodata_segments = set()
@@ -222,6 +233,9 @@ class CommonSegC(CommonSegCodeSubsegment):
                     spimdisasm.mips.FilesHandlers.writeFunctionRodataToFile(
                         f, func, rdata_list, late_rodata_list, late_rodata_size
                     )
+
+                    self.check_gaps_in_migrated_rodata(func, rdata_list)
+                    self.check_gaps_in_migrated_rodata(func, late_rodata_list)
 
             f.write(func.disassemble())
 

--- a/segtypes/common/c.py
+++ b/segtypes/common/c.py
@@ -1,7 +1,7 @@
 import os
 import re
 from pathlib import Path
-from typing import Optional, Set
+from typing import Optional, Set, List
 
 import spimdisasm
 
@@ -160,7 +160,7 @@ class CommonSegC(CommonSegCodeSubsegment):
     def check_gaps_in_migrated_rodata(
         self,
         func: spimdisasm.mips.symbols.SymbolFunction,
-        rodata_list: list[spimdisasm.mips.symbols.SymbolBase],
+        rodata_list: List[spimdisasm.mips.symbols.SymbolBase],
     ):
         for index in range(len(rodata_list) - 1):
             rodata_sym = rodata_list[index]
@@ -209,8 +209,8 @@ class CommonSegC(CommonSegCodeSubsegment):
                     func_rodata = list({s for s in self.parent.rodata_syms[func.vram]})
                     func_rodata.sort(key=lambda s: s.vram_start)
 
-                    rdata_list: list[spimdisasm.mips.symbols.SymbolBase] = []
-                    late_rodata_list: list[spimdisasm.mips.symbols.SymbolBase] = []
+                    rdata_list: List[spimdisasm.mips.symbols.SymbolBase] = []
+                    late_rodata_list: List[spimdisasm.mips.symbols.SymbolBase] = []
                     late_rodata_size = 0
 
                     processed_rodata_segments = set()

--- a/segtypes/common/c.py
+++ b/segtypes/common/c.py
@@ -157,16 +157,28 @@ class CommonSegC(CommonSegCodeSubsegment):
 
         return ret
 
-    def check_gaps_in_migrated_rodata(self, func: spimdisasm.mips.symbols.SymbolFunction, rodata_list: list[spimdisasm.mips.symbols.SymbolBase]):
-        for index in range(len(rodata_list)-1):
+    def check_gaps_in_migrated_rodata(
+        self,
+        func: spimdisasm.mips.symbols.SymbolFunction,
+        rodata_list: list[spimdisasm.mips.symbols.SymbolBase],
+    ):
+        for index in range(len(rodata_list) - 1):
             rodata_sym = rodata_list[index]
-            next_rodata_sym = rodata_list[index+1]
+            next_rodata_sym = rodata_list[index + 1]
 
             if rodata_sym.vramEnd != next_rodata_sym.vram:
-                log.write(f"\nA gap was detected in migrated rodata symbols!", status="warn")
-                log.write(f"\t In function '{func.getName()}' (0x{func.vram:08X}), gap detected between '{rodata_sym.getName()}' (0x{rodata_sym.vram:08X}) and '{next_rodata_sym.getName()}' (0x{next_rodata_sym.vram:08X})")
-                log.write(f"\t The address of the missing rodata symbol is 0x{rodata_sym.vramEnd:08X}.")
-                log.write(f"\t Try to force the migration of that symbol with `force_migration:True` in the symbol_addrs.txt file; or avoid the migration of symbols around this address with `force:not_migration:True`")
+                log.write(
+                    f"\nA gap was detected in migrated rodata symbols!", status="warn"
+                )
+                log.write(
+                    f"\t In function '{func.getName()}' (0x{func.vram:08X}), gap detected between '{rodata_sym.getName()}' (0x{rodata_sym.vram:08X}) and '{next_rodata_sym.getName()}' (0x{next_rodata_sym.vram:08X})"
+                )
+                log.write(
+                    f"\t The address of the missing rodata symbol is 0x{rodata_sym.vramEnd:08X}"
+                )
+                log.write(
+                    f"\t Try to force the migration of that symbol with `force_migration:True` in the symbol_addrs.txt file; or avoid the migration of symbols around this address with `force:not_migration:True`"
+                )
 
     def create_c_asm_file(
         self,

--- a/split.py
+++ b/split.py
@@ -17,7 +17,7 @@ from segtypes.linker_entry import LinkerWriter, to_cname
 from segtypes.segment import Segment
 from util import compiler, log, options, palettes, symbols, relocs
 
-VERSION = "0.12.11"
+VERSION = "0.12.12"
 # This value should be keep in sync with the version listed on requirements.txt
 SPIMDISASM_MIN = (1, 10, 0)
 


### PR DESCRIPTION
Try to detect and warn to the user if a gap between two migrated rodata symbols is detected and suggest possible solutions to the user.

A gap in migrated rodata symbols is a situation when some symbols are migrated to a function but some symbols in the middle of said symbols are not migrated for whatever reason.

Example of the warning:
```
A gap was detected in migrated rodata symbols!
         In function 'menuMain_input' (0x8004F358), gap detected between '_mesNoCont2' (0x800AF3C4) and 'jtbl_800B0450' (0x800B0450)
         The address of the missing rodata symbol is 0x800AF3F8
         Try to force the migration of that symbol with `force_migration:True` in the symbol_addrs.txt file; or avoid the migration of symbols around this address with `force:not_migration:True`
```