### PR TITLE
Allow omitting the rom offset in bss segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # splat Release Notes
 
+### 0.12.13
+
+* bss segments can now omit the rom offset
+
 ### 0.12.12
 
 * Try to detect and warn to the user if a gap between two migrated rodata symbols is detected and suggest possible solutions to the user.

--- a/segtypes/common/c.py
+++ b/segtypes/common/c.py
@@ -136,7 +136,9 @@ class CommonSegC(CommonSegCodeSubsegment):
 
                 self.create_asm_dependencies_file(c_path, asm_out_dir, is_new_c_file)
 
-            assert self.spim_section is not None, f"{self.name}, rom_start:{self.rom_start}, rom_end:{self.rom_end}"
+            assert (
+                self.spim_section is not None
+            ), f"{self.name}, rom_start:{self.rom_start}, rom_end:{self.rom_end}"
             for func in self.spim_section.symbolList:
                 if func.getName() in self.global_asm_funcs or is_new_c_file:
                     assert func.vram is not None

--- a/segtypes/common/c.py
+++ b/segtypes/common/c.py
@@ -120,7 +120,7 @@ class CommonSegC(CommonSegCodeSubsegment):
             self.scan_code(rom_bytes)
 
     def split(self, rom_bytes: bytes):
-        if not self.rom_start == self.rom_end:
+        if self.rom_start != self.rom_end:
             asm_out_dir = options.opts.nonmatchings_path / self.dir
             asm_out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -136,7 +136,7 @@ class CommonSegC(CommonSegCodeSubsegment):
 
                 self.create_asm_dependencies_file(c_path, asm_out_dir, is_new_c_file)
 
-            assert self.spim_section is not None
+            assert self.spim_section is not None, f"{self.name}, rom_start:{self.rom_start}, rom_end:{self.rom_end}"
             for func in self.spim_section.symbolList:
                 if func.getName() in self.global_asm_funcs or is_new_c_file:
                     assert func.vram is not None

--- a/segtypes/common/code.py
+++ b/segtypes/common/code.py
@@ -218,6 +218,8 @@ class CommonSegCode(CommonSegGroup):
 
         inserts = self.find_inserts(found_sections)
 
+        last_rom_end = 0
+
         for i, subsection_yaml in enumerate(segment_yaml["subsegments"]):
             # endpos marker
             if isinstance(subsection_yaml, list) and len(subsection_yaml) == 1:
@@ -265,6 +267,12 @@ class CommonSegCode(CommonSegGroup):
                 assert isinstance(start, int)
                 vram = self.get_most_parent().rom_to_ram(start)
 
+            if segment_class.is_noload():
+                # Pretend bss's rom address is after the last actual rom segment
+                start = last_rom_end
+                # and it has a rom size of zero
+                end = last_rom_end
+
             segment: Segment = Segment.from_yaml(
                 segment_class, subsection_yaml, start, end, vram
             )
@@ -290,6 +298,8 @@ class CommonSegCode(CommonSegGroup):
                 base_segments[segment.name] = segment
 
             prev_start = start
+            if end is not None:
+                last_rom_end = end
 
         # Add the automatic all_ sections
         orig_len = len(ret)

--- a/segtypes/common/codesubsegment.py
+++ b/segtypes/common/codesubsegment.py
@@ -197,6 +197,8 @@ class CommonSegCodeSubsegment(Segment):
         )
 
     def should_split(self) -> bool:
-        return self.extract and (
-            self.partial_migration or options.opts.is_mode_active("code")
-        ) and self.should_scan() # only split if the segment was scanned first
+        return (
+            self.extract
+            and (self.partial_migration or options.opts.is_mode_active("code"))
+            and self.should_scan()
+        )  # only split if the segment was scanned first

--- a/segtypes/common/codesubsegment.py
+++ b/segtypes/common/codesubsegment.py
@@ -199,4 +199,4 @@ class CommonSegCodeSubsegment(Segment):
     def should_split(self) -> bool:
         return self.extract and (
             self.partial_migration or options.opts.is_mode_active("code")
-        )
+        ) and self.should_scan() # only split if the segment was scanned first

--- a/segtypes/common/data.py
+++ b/segtypes/common/data.py
@@ -24,7 +24,7 @@ class CommonSegData(CommonSegCodeSubsegment, CommonSegGroup):
     def scan(self, rom_bytes: bytes):
         CommonSegGroup.scan(self, rom_bytes)
 
-        if super().should_scan():
+        if self.should_scan():
             self.disassemble_data(rom_bytes)
 
     def split(self, rom_bytes: bytes):
@@ -55,9 +55,6 @@ class CommonSegData(CommonSegCodeSubsegment, CommonSegGroup):
         return options.opts.is_mode_active("data")
 
     def should_split(self) -> bool:
-        return True
-
-    def should_scan(self) -> bool:
         return True
 
     def cache(self):

--- a/segtypes/common/data.py
+++ b/segtypes/common/data.py
@@ -54,6 +54,11 @@ class CommonSegData(CommonSegCodeSubsegment, CommonSegGroup):
     def should_self_split(self) -> bool:
         return options.opts.is_mode_active("data")
 
+    def should_scan(self) -> bool:
+        # Ensure data segments are scanned even if extract is False so subsegments get scanned too
+        # Check for not None so we avoid scanning "auto" segments
+        return self.rom_start is not None and self.rom_end is not None
+
     def should_split(self) -> bool:
         return True
 

--- a/segtypes/common/group.py
+++ b/segtypes/common/group.py
@@ -43,6 +43,7 @@ class CommonSegGroup(CommonSegment):
             return ret
 
         prev_start: Optional[int] = -1
+        last_rom_end = 0
 
         for i, subsection_yaml in enumerate(yaml["subsegments"]):
             # endpos marker
@@ -70,6 +71,12 @@ class CommonSegGroup(CommonSegment):
                 assert isinstance(start, int)
                 vram = self.get_most_parent().rom_to_ram(start)
 
+            if segment_class.is_noload():
+                # Pretend bss's rom address is after the last actual rom segment
+                start = last_rom_end
+                # and it has a rom size of zero
+                end = last_rom_end
+
             segment: Segment = Segment.from_yaml(
                 segment_class, subsection_yaml, start, end, vram
             )
@@ -79,6 +86,8 @@ class CommonSegGroup(CommonSegment):
 
             ret.append(segment)
             prev_start = start
+            if end is not None:
+                last_rom_end = end
 
         return ret
 

--- a/segtypes/segment.py
+++ b/segtypes/segment.py
@@ -287,6 +287,11 @@ class Segment:
             ret.align = parse_segment_align(yaml)
         return ret
 
+    # For segments which does not take space in ROM, like bss
+    @staticmethod
+    def is_noload() -> bool:
+        return False
+
     @property
     def needs_symbols(self) -> bool:
         return False

--- a/split.py
+++ b/split.py
@@ -17,7 +17,7 @@ from segtypes.linker_entry import LinkerWriter, to_cname
 from segtypes.segment import Segment
 from util import compiler, log, options, palettes, symbols, relocs
 
-VERSION = "0.12.12"
+VERSION = "0.12.13"
 # This value should be keep in sync with the version listed on requirements.txt
 SPIMDISASM_MIN = (1, 10, 0)
 


### PR DESCRIPTION
Allow omitting the rom offset (`start:` in the yaml) for bss segments.

Example of current behavior:
```yaml

      - { start: 0x09B460, type: bss, vram: 0x800B3640, name: main_segment/800B3640 }
      - { start: 0x09B460, type: bss, vram: 0x800E99C0, name: libmus/aud_sched }
      - { start: 0x09B460, type: bss, vram: 0x800E99D0, name: main_segment/800E99D0 }

      - { start: 0x09B460, type: bss, vram: 0x800E9BA0, name: libmus/aud_samples }

      - { start: 0x09B460, type: bss, vram: 0x800E9BB0, name: main_segment/800E9BB0 }

      - { start: 0x09B460, type: bss, vram: 0x800F8C90, name: libmus/aud_thread }

      - { start: 0x09B460, type: bss, vram: 0x800F8CE0, name: main_segment/800F8CE0 }

```
New:
```yaml

      - { type: bss, vram: 0x800B3640, name: main_segment/800B3640 }
      - { type: bss, vram: 0x800E99C0, name: libmus/aud_sched }
      - { type: bss, vram: 0x800E99D0, name: main_segment/800E99D0 }

      - { type: bss, vram: 0x800E9BA0, name: libmus/aud_samples }

      - { type: bss, vram: 0x800E9BB0, name: main_segment/800E9BB0 }

      - { type: bss, vram: 0x800F8C90, name: libmus/aud_thread }

      - { type: bss, vram: 0x800F8CE0, name: main_segment/800F8CE0 }
```

This works by pretending the bss vrom address is at the end of the last processed segment, and the bss segment has a rom size of zero.

I also made a few miscellaneous cleanups in some asserts