### PR TITLE
Hint to which segment a rodata segment belongs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # splat Release Notes
 
+### 0.12.13
+
+* New option: `find_rodata_to_text`.
+  * If enabled, splat will try to find to which text segment an unpaired rodata segment belongs and it will hint it to the user.
+
 ### 0.12.12
 
 * Try to detect and warn to the user if a gap between two migrated rodata symbols is detected and suggest possible solutions to the user.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 0.12.14
 
-* New option: `find_rodata_to_text`.
+* New option: `pair_rodata_to_text`.
   * If enabled, splat will try to find to which text segment an unpaired rodata segment belongs and it will hint it to the user.
 
 ### 0.12.13

--- a/segtypes/common/asm.py
+++ b/segtypes/common/asm.py
@@ -7,6 +7,10 @@ from segtypes.common.codesubsegment import CommonSegCodeSubsegment
 
 
 class CommonSegAsm(CommonSegCodeSubsegment):
+    @staticmethod
+    def is_text() -> bool:
+        return True
+
     def out_path(self) -> Optional[Path]:
         return options.opts.asm_path / self.dir / f"{self.name}.s"
 

--- a/segtypes/common/c.py
+++ b/segtypes/common/c.py
@@ -99,6 +99,10 @@ class CommonSegC(CommonSegCodeSubsegment):
                 m.group(2) for m in CommonSegC.C_GLOBAL_ASM_IDO_RE.finditer(text)
             )
 
+    @staticmethod
+    def is_text() -> bool:
+        return True
+
     def out_path(self) -> Optional[Path]:
         return options.opts.src_path / self.dir / f"{self.name}.c"
 

--- a/segtypes/common/group.py
+++ b/segtypes/common/group.py
@@ -116,7 +116,7 @@ class CommonSegGroup(CommonSegment):
 
         return c
 
-    def get_subsegment_for_ram(self, addr) -> Optional[Segment]:
+    def get_subsegment_for_ram(self, addr: int) -> Optional[Segment]:
         for sub in self.subsegments:
             if sub.contains_vram(addr):
                 return sub

--- a/segtypes/common/rodata.py
+++ b/segtypes/common/rodata.py
@@ -1,4 +1,6 @@
+from typing import Optional, Set, Tuple
 import spimdisasm
+from segtypes.segment import Segment
 from util import log, options, symbols
 
 from segtypes.common.data import CommonSegData
@@ -7,6 +9,25 @@ from segtypes.common.data import CommonSegData
 class CommonSegRodata(CommonSegData):
     def get_linker_section(self) -> str:
         return ".rodata"
+
+    def get_possible_text_subsegment_for_symbol(self, rodata_sym: spimdisasm.mips.symbols.SymbolBase) -> Optional[Tuple[Segment, spimdisasm.common.ContextSymbol]]:
+        # Check if this rodata segment does not have a corresponding code file, try to look for one
+
+        if self.sibling is not None or not options.opts.find_rodata_to_text:
+            return None
+
+        if not rodata_sym.shouldMigrate():
+            return
+
+        if len(rodata_sym.contextSym.referenceFunctions) != 1:
+            return None
+
+        func = list(rodata_sym.contextSym.referenceFunctions)[0]
+        text_segment = self.parent.get_subsegment_for_ram(func.vram)
+
+        if text_segment is None or not text_segment.is_text():
+            return None
+        return text_segment, func
 
     def disassemble_data(self, rom_bytes):
         if not isinstance(self.rom_start, int):
@@ -49,10 +70,21 @@ class CommonSegRodata(CommonSegData):
         self.spim_section.analyze()
         self.spim_section.setCommentOffset(self.rom_start)
 
+        possible_text_segments: Set[Segment] = set()
+
         for symbol in self.spim_section.symbolList:
             symbols.create_symbol_from_spim_symbol(
                 self.get_most_parent(), symbol.contextSym
             )
+
+            possible_text = self.get_possible_text_subsegment_for_symbol(symbol)
+            if possible_text is not None:
+                text_segment, refenceeFunction = possible_text
+                if text_segment not in possible_text_segments:
+                    print(f"\nRodata segment '{self.name}' may belong to the text segment '{text_segment.name}'")
+                    print(f"    Based on the usage from the function {refenceeFunction.getName()} to the symbol {symbol.getName()}")
+                    possible_text_segments.add(text_segment)
+
 
     def split(self, rom_bytes: bytes):
         # Disassemble the file itself

--- a/segtypes/common/rodata.py
+++ b/segtypes/common/rodata.py
@@ -15,7 +15,7 @@ class CommonSegRodata(CommonSegData):
     ) -> Optional[Tuple[Segment, spimdisasm.common.ContextSymbol]]:
         # Check if this rodata segment does not have a corresponding code file, try to look for one
 
-        if self.sibling is not None or not options.opts.find_rodata_to_text:
+        if self.sibling is not None or not options.opts.pair_rodata_to_text:
             return None
 
         if not rodata_sym.shouldMigrate():

--- a/segtypes/common/rodata.py
+++ b/segtypes/common/rodata.py
@@ -10,14 +10,16 @@ class CommonSegRodata(CommonSegData):
     def get_linker_section(self) -> str:
         return ".rodata"
 
-    def get_possible_text_subsegment_for_symbol(self, rodata_sym: spimdisasm.mips.symbols.SymbolBase) -> Optional[Tuple[Segment, spimdisasm.common.ContextSymbol]]:
+    def get_possible_text_subsegment_for_symbol(
+        self, rodata_sym: spimdisasm.mips.symbols.SymbolBase
+    ) -> Optional[Tuple[Segment, spimdisasm.common.ContextSymbol]]:
         # Check if this rodata segment does not have a corresponding code file, try to look for one
 
         if self.sibling is not None or not options.opts.find_rodata_to_text:
             return None
 
         if not rodata_sym.shouldMigrate():
-            return
+            return None
 
         if len(rodata_sym.contextSym.referenceFunctions) != 1:
             return None
@@ -81,10 +83,13 @@ class CommonSegRodata(CommonSegData):
             if possible_text is not None:
                 text_segment, refenceeFunction = possible_text
                 if text_segment not in possible_text_segments:
-                    print(f"\nRodata segment '{self.name}' may belong to the text segment '{text_segment.name}'")
-                    print(f"    Based on the usage from the function {refenceeFunction.getName()} to the symbol {symbol.getName()}")
+                    print(
+                        f"\nRodata segment '{self.name}' may belong to the text segment '{text_segment.name}'"
+                    )
+                    print(
+                        f"    Based on the usage from the function {refenceeFunction.getName()} to the symbol {symbol.getName()}"
+                    )
                     possible_text_segments.add(text_segment)
-
 
     def split(self, rom_bytes: bytes):
         # Disassemble the file itself

--- a/segtypes/segment.py
+++ b/segtypes/segment.py
@@ -287,6 +287,11 @@ class Segment:
             ret.align = parse_segment_align(yaml)
         return ret
 
+    # For segments executable (.text) sections, like c, asm and hasm
+    @staticmethod
+    def is_text() -> bool:
+        return False
+
     @property
     def needs_symbols(self) -> bool:
         return False

--- a/split.py
+++ b/split.py
@@ -17,7 +17,7 @@ from segtypes.linker_entry import LinkerWriter, to_cname
 from segtypes.segment import Segment
 from util import compiler, log, options, palettes, symbols, relocs
 
-VERSION = "0.12.12"
+VERSION = "0.12.13"
 # This value should be keep in sync with the version listed on requirements.txt
 SPIMDISASM_MIN = (1, 10, 0)
 

--- a/util/options.py
+++ b/util/options.py
@@ -120,7 +120,7 @@ class SplatOpts:
     # Determines whether to detect and hint to the user about likely file splits when disassembling
     find_file_boundaries: bool
     # Determines whether to detect and hint to the user about possible rodata sections corresponding to a text section
-    find_rodata_to_text: bool
+    pair_rodata_to_text: bool
     # Determines whether to attempt to automatically migrate rodata into functions
     # (only works in certain circumstances)
     migrate_rodata_to_functions: bool
@@ -351,7 +351,7 @@ def _parse_yaml(
             "symbol_name_format_no_rom", str, "$VRAM_$SEG"
         ),
         find_file_boundaries=p.parse_opt("find_file_boundaries", bool, True),
-        find_rodata_to_text=p.parse_opt("find_rodata_to_text", bool, True),
+        pair_rodata_to_text=p.parse_opt("pair_rodata_to_text", bool, True),
         migrate_rodata_to_functions=p.parse_opt(
             "migrate_rodata_to_functions", bool, True
         ),

--- a/util/options.py
+++ b/util/options.py
@@ -119,6 +119,8 @@ class SplatOpts:
     symbol_name_format_no_rom: str
     # Determines whether to detect and hint to the user about likely file splits when disassembling
     find_file_boundaries: bool
+    # Determines whether to detect and hint to the user about possible rodata sections corresponding to a text section
+    find_rodata_to_text: bool
     # Determines whether to attempt to automatically migrate rodata into functions
     # (only works in certain circumstances)
     migrate_rodata_to_functions: bool
@@ -349,6 +351,7 @@ def _parse_yaml(
             "symbol_name_format_no_rom", str, "$VRAM_$SEG"
         ),
         find_file_boundaries=p.parse_opt("find_file_boundaries", bool, True),
+        find_rodata_to_text=p.parse_opt("find_rodata_to_text", bool, True),
         migrate_rodata_to_functions=p.parse_opt(
             "migrate_rodata_to_functions", bool, True
         ),


### PR DESCRIPTION
- Adds a new option: `find_rodata_to_text` (open to better name suggestions).
- If enabled, splat will try to find to which text segment an unpaired rodata segment belongs and it will hint it to the user.

Example output:
```

Rodata segment 'boot/0012240' may belong to the text segment 'libultra/sched'
    Based on the usage from the function __scSchedule to the symbol jtbl_80011640

Rodata segment 'boot/0012260' may belong to the text segment 'libultra/os/exceptasm'
    Based on the usage from the function __osException to the symbol jtbl_80011680

Rodata segment 'boot/00122B0' may belong to the text segment 'libultra/devmgr'
    Based on the usage from the function __osDevMgrMain to the symbol jtbl_80011730

Rodata segment 'boot/00122B0' may belong to the text segment 'libultra/drvrNew'
    Based on the usage from the function alFxNew to the symbol jtbl_80011750

```

Second example:
```
Rodata segment 'main_segment/0ABCB0' may belong to the text segment 'main_segment/0187C0'
    Based on the usage from the function func_800357CC_cn to the symbol jtbl_800C3F80

Rodata segment 'main_segment/0ABD40' may belong to the text segment 'main_segment/0187C0'
    Based on the usage from the function func_80039964_cn to the symbol jtbl_800C4020
```
Since two different rodata segments are paired to the same text segment this means either there's a missing split in `main_segment/0187C0` or `main_segment/0ABCB0` and `main_segment/0ABD40` should be merged together

Third example:
```
Rodata segment 'main_segment/0ABE80' may belong to the text segment 'main_segment/025650'
    Based on the usage from the function func_8003F90C_cn to the symbol RO_800C41F0_cn

Rodata segment 'main_segment/0ABE80' may belong to the text segment 'main_segment/028350'
    Based on the usage from the function func_800407C4_cn to the symbol RO_800C447C_cn
```
The other way around can also happen too, where a rodata segment is hinted to belong to two different text segments. Same logic applies here, meaning there's either a missing split or an over split.