### PR TITLE
Add bss info to `create_config.py`

### DIFF
--- a/create_config.py
+++ b/create_config.py
@@ -102,7 +102,10 @@ segments:
       - [0x1000, asm]
 """
 
-    if rom.entrypoint_info.bss_size is not None and rom.entrypoint_info.bss_start_address is not None:
+    if (
+        rom.entrypoint_info.bss_size is not None
+        and rom.entrypoint_info.bss_start_address is not None
+    ):
         bss_start = rom.entrypoint_info.bss_start_address - rom.entry_point + 0x1000
         # first_section_end points to the start of data
         segments += f"""\

--- a/create_config.py
+++ b/create_config.py
@@ -73,17 +73,50 @@ segments:
   - name: header
     type: header
     start: 0x0
+
   - name: boot
     type: bin
     start: 0x40
-  - name: main
+
+  - name: entry
     type: code
     start: 0x1000
     vram: 0x{rom.entry_point:X}
     subsegments:
+      - [0x1000, hasm]
+
+  - name: main
+    type: code
+    start: 0x{0x1000 + rom.entrypoint_info.entry_size:X}
+    vram: 0x{rom.entry_point + rom.entrypoint_info.entry_size:X}
+    follows_vram: entry
+"""
+
+    if rom.entrypoint_info.bss_size is not None:
+        segments += f"""\
+    bss_size: 0x{rom.entrypoint_info.bss_size:X}
+"""
+
+    segments += f"""\
+    subsegments:
       - [0x1000, asm]
+"""
+
+    if rom.entrypoint_info.bss_size is not None and rom.entrypoint_info.bss_start_address is not None:
+        bss_start = rom.entrypoint_info.bss_start_address - rom.entry_point + 0x1000
+        # first_section_end points to the start of data
+        segments += f"""\
+      - [0x{first_section_end:X}, data]
+      - {{ start: 0x{bss_start:X}, type: bss, vram: 0x{rom.entrypoint_info.bss_start_address:08X} }}
+"""
+        # Point next segment to the detected end of the main one
+        first_section_end = bss_start
+
+    segments += f"""\
+
   - type: bin
     start: 0x{first_section_end:X}
+    follows_vram: main
   - [0x{rom.size:X}]
 """
 

--- a/create_config.py
+++ b/create_config.py
@@ -99,7 +99,7 @@ segments:
 
     segments += f"""\
     subsegments:
-      - [0x1000, asm]
+      - [0x{0x1000 + rom.entrypoint_info.entry_size:X}, asm]
 """
 
     if (

--- a/util/n64/rominfo.py
+++ b/util/n64/rominfo.py
@@ -72,9 +72,9 @@ unknown_cic = CIC("unknown", "unknown", 0x0000000)
 @dataclass
 class N64EntrypointInfo:
     entry_size: int
-    bss_start_address: int | None
-    bss_size: int | None
-    main_address: int | None
+    bss_start_address: Optional[int]
+    bss_size: Optional[int]
+    main_address: Optional[int]
     stack_top: int
 
     @staticmethod
@@ -88,9 +88,9 @@ class N64EntrypointInfo:
 
         register_values = [0 for _ in range(32)]
 
-        register_bss_address: int | None = None
-        register_bss_size: int | None = None
-        register_main_address: int | None = None
+        register_bss_address: Optional[int] = None
+        register_bss_size: Optional[int] = None
+        register_main_address: Optional[int] = None
 
         size = 0
         for word in word_list:

--- a/util/n64/rominfo.py
+++ b/util/n64/rominfo.py
@@ -72,21 +72,25 @@ unknown_cic = CIC("unknown", "unknown", 0x0000000)
 @dataclass
 class N64EntrypointInfo:
     entry_size: int
-    bss_start_address: int|None
-    bss_size: int|None
-    main_address: int|None
+    bss_start_address: int | None
+    bss_size: int | None
+    main_address: int | None
     stack_top: int
 
     @staticmethod
-    def parse_rom_bytes(rom_bytes, offset: int=0x1000, size: int=0x60) -> "N64EntrypointInfo":
-        word_list = spimdisasm.common.Utils.bytesToWords(rom_bytes, offset, offset+size)
+    def parse_rom_bytes(
+        rom_bytes, offset: int = 0x1000, size: int = 0x60
+    ) -> "N64EntrypointInfo":
+        word_list = spimdisasm.common.Utils.bytesToWords(
+            rom_bytes, offset, offset + size
+        )
         nops_count = 0
 
         register_values = [0 for _ in range(32)]
 
-        register_bss_address: int|None = None
-        register_bss_size: int|None = None
-        register_main_address: int|None = None
+        register_bss_address: int | None = None
+        register_bss_size: int | None = None
+        register_main_address: int | None = None
 
         size = 0
         for word in word_list:
@@ -107,7 +111,9 @@ class N64EntrypointInfo:
                     # addi        $t1, $t1, -0x8
                     pass
                 elif insn.modifiesRt():
-                    register_values[insn.rt.value] = register_values[insn.rs.value] + insn.getProcessedImmediate()
+                    register_values[insn.rt.value] = (
+                        register_values[insn.rs.value] + insn.getProcessedImmediate()
+                    )
                 elif insn.doesStore():
                     if insn.rt == rabbitizer.RegGprO32.zero:
                         # Try to detect the zero-ing bss algorithm
@@ -135,9 +141,21 @@ class N64EntrypointInfo:
         # for i, val in enumerate(register_values):
         #     print(i, f"{val:08X}")
 
-        bss_address = register_values[register_bss_address] if register_bss_address is not None else None
-        bss_size = register_values[register_bss_size] if register_bss_size is not None else None
-        main_address = register_values[register_main_address] if register_main_address is not None else None
+        bss_address = (
+            register_values[register_bss_address]
+            if register_bss_address is not None
+            else None
+        )
+        bss_size = (
+            register_values[register_bss_size]
+            if register_bss_size is not None
+            else None
+        )
+        main_address = (
+            register_values[register_main_address]
+            if register_main_address is not None
+            else None
+        )
         stack_top = register_values[rabbitizer.RegGprO32.sp.value]
         return N64EntrypointInfo(size, bss_address, bss_size, main_address, stack_top)
 
@@ -205,7 +223,9 @@ def guess_header_encoding(rom_bytes: bytes):
     sys.exit("Unknown header encoding, please raise an Issue with us")
 
 
-def get_info(rom_path: Path, rom_bytes: Optional[bytes] = None, header_encoding=None) -> N64Rom:
+def get_info(
+    rom_path: Path, rom_bytes: Optional[bytes] = None, header_encoding=None
+) -> N64Rom:
     if rom_bytes is None:
         rom_bytes = read_rom(rom_path)
 


### PR DESCRIPTION
The script now parses the entrypoint and tries to extract `bss` information and use it to create the initial yaml.

Now the script is able to now where the `data` section more or less starts too

Example yaml generated with current master:
```yaml
name: Dr.Mario 64 (North America)
sha1: a130d3622ce40e0158db2da4247101f6e92206fc
options:
  basename: dr.mario64
  target_path: baserom.us.z64
  base_path: .
  compiler: GCC
  find_file_boundaries: True
  header_encoding: ASCII
  platform: n64
  # undefined_funcs_auto: True
  # undefined_funcs_auto_path: undefined_funcs_auto.txt
  # undefined_syms_auto: True
  # undefined_syms_auto_path: undefined_syms_auto.txt
  # symbol_addrs_path: symbol_addrs.txt
  # asm_path: asm
  # src_path: src
  # build_path: build
  # extensions_path: tools/splat_ext
  # mips_abi_float_regs: o32
  # section_order: [".text", ".data", ".rodata", ".bss"]
  # auto_all_sections: [".data", ".rodata", ".bss"]
  # libultra_symbols: True
  # hardware_regs: True
segments:
  - name: header
    type: header
    start: 0x0
  - name: boot
    type: bin
    start: 0x40
  - name: main
    type: code
    start: 0x1000
    vram: 0x80000400
    subsegments:
      - [0x1000, asm]
  - type: bin
    start: 0xED90
  - [0x400000]
```

yaml outputted with this PR:
```yaml
name: Dr.Mario 64 (North America)
sha1: a130d3622ce40e0158db2da4247101f6e92206fc
options:
  basename: dr.mario64
  target_path: ../drmario64/baserom.us.z64
  base_path: .
  compiler: GCC
  find_file_boundaries: True
  header_encoding: ASCII
  platform: n64
  # undefined_funcs_auto: True
  # undefined_funcs_auto_path: undefined_funcs_auto.txt
  # undefined_syms_auto: True
  # undefined_syms_auto_path: undefined_syms_auto.txt
  # symbol_addrs_path: symbol_addrs.txt
  # asm_path: asm
  # src_path: src
  # build_path: build
  # extensions_path: tools/splat_ext
  # mips_abi_float_regs: o32
  # section_order: [".text", ".data", ".rodata", ".bss"]
  # auto_all_sections: [".data", ".rodata", ".bss"]
  # libultra_symbols: True
  # hardware_regs: True
segments:
  - name: header
    type: header
    start: 0x0

  - name: boot
    type: bin
    start: 0x40

  - name: entry
    type: code
    start: 0x1000
    vram: 0x80000400
    subsegments:
      - [0x1000, hasm]

  - name: main
    type: code
    start: 0x1060
    vram: 0x80000460
    follows_vram: entry
    bss_size: 0x18DE0
    subsegments:
      - [0x1000, asm]
      - [0xED90, data]
      - { start: 0x11A60, type: bss, vram: 0x80010E60 }

  - type: bin
    start: 0x11A60
    follows_vram: main
  - [0x400000]
```