### PR TITLE
Error on unknown types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,26 @@
 # splat Release Notes
 
+### 0.13.5
+
+* An error will be produced if a symbol is declared with an unknown type in the symbol_addrs file.
+  * The current list of known symbols is `'func', 'label', 'jtbl', 'jtbl_label', 's8', 'u8', 's16', 'u16', 's32', 'u32', 's64', 'u64', 'f32', 'f64', 'Vec3f', 'asciz', 'char*', 'char'`.
+  * Custom types are allowed if they start with a capital letter.
+
 ### 0.13.4
+
 * Renamed `follows_vram_symbol` segment option to `vram_of_symbol` to more accurately reflect what it's used for - to set the segment's vram based on a symbol.
 * Refactored the `appears_after_overlays_addr` feature so that expressions are written at the latest possible moment in the linker script. This fixes errors and warnings regarding forward references to later symbols.
 
 ### 0.13.3
-* Added a new symbol_addrs attribute `appears_after_overlays_addr:0x1234` which will modify the linker script such that the symbol's address is equal to the value of the end of the longest overlay starting with address 0x1234. It achieve this by writing a series of sym = MAX(sym, seg_vram_END) statements into the linker script. For some games, it's feasible to manually create such statements, but for games with hundreds of overlays at the same address, this is very tedious and prone to error. The new attribute allows you to have peace of mind that the symbol will end up after all of these overlays. 
+
+* Added a new symbol_addrs attribute `appears_after_overlays_addr:0x1234` which will modify the linker script such that the symbol's address is equal to the value of the end of the longest overlay starting with address 0x1234. It achieve this by writing a series of sym = MAX(sym, seg_vram_END) statements into the linker script. For some games, it's feasible to manually create such statements, but for games with hundreds of overlays at the same address, this is very tedious and prone to error. The new attribute allows you to have peace of mind that the symbol will end up after all of these overlays.
 
 ### 0.13.2
+
 * Actually implemented `ld_use_follows`. Oopz
 
 ### 0.13.1
+
 * Added `ld_wildcard_sections` option (disabled by default), which adds a wildcard to the linker script for section linking. This can be helpful for modern GCC, which creates additional rodata sections such as ".rodata.xyz".
 * Added `ld_use_follows` option (enabled by default), which, if disabled, makes splat ignore follows_vram and follows_symbols. This helps for fixing matching builds while being able to add infrastructure to the yaml for non-matching builds by just re-enabling the option.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ tqdm
 intervaltree
 colorama
 # This value should be keep in sync with the version listed on split.py
-spimdisasm>=1.11.1
+spimdisasm>=1.12.0
 rabbitizer>=1.4.0
 pygfxd
 n64img>=0.1.4

--- a/split.py
+++ b/split.py
@@ -23,9 +23,9 @@ from util import compiler, log, options, palettes, symbols, relocs
 
 from util.symbols import Symbol
 
-VERSION = "0.13.4"
+VERSION = "0.13.5"
 # This value should be kept in sync with the version listed on requirements.txt
-SPIMDISASM_MIN = (1, 11, 1)
+SPIMDISASM_MIN = (1, 12, 0)
 
 parser = argparse.ArgumentParser(
     description="Split a rom given a rom, a config, and output directory"

--- a/util/symbols.py
+++ b/util/symbols.py
@@ -25,9 +25,8 @@ spim_context = spimdisasm.common.Context()
 TRUEY_VALS = ["true", "on", "yes", "y"]
 FALSEY_VALS = ["false", "off", "no", "n"]
 
-splat_sym_types = {
-    "func", "jtbl", "jtbl_label", "label"
-}
+splat_sym_types = {"func", "jtbl", "jtbl_label", "label"}
+
 
 def check_valid_type(typename: str) -> bool:
     if typename[0].isupper():
@@ -40,6 +39,7 @@ def check_valid_type(typename: str) -> bool:
         return True
 
     return False
+
 
 def is_truey(str: str) -> bool:
     return str.lower() in TRUEY_VALS
@@ -146,10 +146,21 @@ def initialize(all_segments: "List[Segment]"):
                                     try:
                                         if attr_name == "type":
                                             if not check_valid_type(attr_val):
-                                                log.parsing_error_preamble(path, line_num, line)
-                                                log.write(f"Unrecognized symbol type in '{info}', it should be one of")
-                                                log.write([*splat_sym_types, *spimdisasm.common.gKnownTypes])
-                                                log.write("You may use a custom type that starts with a capital letter")
+                                                log.parsing_error_preamble(
+                                                    path, line_num, line
+                                                )
+                                                log.write(
+                                                    f"Unrecognized symbol type in '{info}', it should be one of"
+                                                )
+                                                log.write(
+                                                    [
+                                                        *splat_sym_types,
+                                                        *spimdisasm.common.gKnownTypes,
+                                                    ]
+                                                )
+                                                log.write(
+                                                    "You may use a custom type that starts with a capital letter"
+                                                )
                                                 log.error("")
                                             type = attr_val
                                             sym.type = type

--- a/util/symbols.py
+++ b/util/symbols.py
@@ -25,6 +25,21 @@ spim_context = spimdisasm.common.Context()
 TRUEY_VALS = ["true", "on", "yes", "y"]
 FALSEY_VALS = ["false", "off", "no", "n"]
 
+splat_sym_types = {
+    "func", "jtbl", "jtbl_label", "label"
+}
+
+def check_valid_type(typename: str) -> bool:
+    if typename[0].isupper():
+        return True
+
+    if typename in splat_sym_types:
+        return True
+
+    if typename in spimdisasm.common.gKnownTypes:
+        return True
+
+    return False
 
 def is_truey(str: str) -> bool:
     return str.lower() in TRUEY_VALS
@@ -130,6 +145,12 @@ def initialize(all_segments: "List[Segment]"):
                                     # Non-Boolean attributes
                                     try:
                                         if attr_name == "type":
+                                            if not check_valid_type(attr_val):
+                                                log.parsing_error_preamble(path, line_num, line)
+                                                log.write(f"Unrecognized symbol type in '{info}', it should be one of")
+                                                log.write([*splat_sym_types, *spimdisasm.common.gKnownTypes])
+                                                log.write("You may use a custom type that starts with a capital letter")
+                                                log.error("")
                                             type = attr_val
                                             sym.type = type
                                             continue


### PR DESCRIPTION
* An error will be produced if a symbol is declared with an unknown type in the symbol_addrs file.
  * The current list of known symbols is `'func', 'label', 'jtbl', 'jtbl_label', 's8', 'u8', 's16', 'u16', 's32', 'u32', 's64', 'u64', 'f32', 'f64', 'Vec3f', 'asciz', 'char*', 'char'`.
  * Custom types are allowed if they start with a capital letter.
