### PR TITLE
Fix bug with null ROM name

### DIFF
--- a/util/n64/rominfo.py
+++ b/util/n64/rominfo.py
@@ -31,8 +31,8 @@ country_codes = {
     0x00: "Unknown",
     0x37: "Beta",
     0x41: "Asian (NTSC)",
-    0x42: "Brazillian",
-    0x43: "Chiniese",
+    0x42: "Brazilian",
+    0x43: "Chinese",
     0x44: "German",
     0x45: "North America",
     0x46: "French",
@@ -46,7 +46,7 @@ country_codes = {
     0x50: "European (basic spec.)",
     0x53: "Spanish",
     0x55: "Australian",
-    0x57: "Scandanavian",
+    0x57: "Scandinavian",
     0x58: "European",
     0x59: "European",
 }
@@ -241,7 +241,7 @@ def get_info_bytes(rom_bytes: bytes, header_encoding: str) -> N64Rom:
     checksum = rom_bytes[0x10:0x18].hex().upper()
 
     try:
-        name = rom_bytes[0x20:0x34].decode(header_encoding).strip()
+        name = rom_bytes[0x20:0x34].decode(header_encoding).rstrip(" \0") or "empty"
     except:
         sys.exit(
             "splat could not decode the game name;"


### PR DESCRIPTION
When the ROM name in the header is null, create_config crashes because it tries to write a null to the yaml. This PR removes potential nulls at the end of the name and if the entire name is empty, replaces it with "empty". Also it doesn't trim whitespace from the left side of the name any more. Also I fixed some typos in the country codes, hope that doesn't break anything