### PR TITLE
`segment_end_before_align`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # splat Release Notes
 
+### 0.13.8
+
+* New option `segment_end_before_align`.
+  * If enabled, the end symbol for each segment will be placed before the alignment directive for the segment
+
 ### 0.13.7
+
 * Severely sped-up linker entry writing by using a dict instead of a list. Symbol headers will no longer be in any specific order (which shouldn't matter, because they're headers).
 
 ### 0.13.6

--- a/segtypes/linker_entry.py
+++ b/segtypes/linker_entry.py
@@ -388,11 +388,16 @@ class LinkerWriter:
             self._writeln(f"__romPos += SIZEOF(.{name});")
 
         # Align directive
-        if segment.align:
-            self._writeln(f"__romPos = ALIGN(__romPos, {segment.align});")
+        if not options.opts.segment_end_before_align:
+            if segment.align:
+                self._writeln(f"__romPos = ALIGN(__romPos, {segment.align});")
 
         self._write_symbol(f"{name}_ROM_END", "__romPos")
-
         self._write_symbol(get_segment_vram_end_symbol_name(segment), ".")
+
+        # Align directive
+        if options.opts.segment_end_before_align:
+            if segment.align:
+                self._writeln(f"__romPos = ALIGN(__romPos, {segment.align});")
 
         self._writeln("")

--- a/split.py
+++ b/split.py
@@ -23,7 +23,7 @@ from util import compiler, log, options, palettes, symbols, relocs
 
 from util.symbols import Symbol
 
-VERSION = "0.13.7"
+VERSION = "0.13.8"
 # This value should be kept in sync with the version listed on requirements.txt
 SPIMDISASM_MIN = (1, 12, 0)
 

--- a/util/options.py
+++ b/util/options.py
@@ -101,6 +101,8 @@ class SplatOpts:
     # Determines whether to use use "follows" settings to determine locations of overlays in the linker script.
     # If disabled, this effectively ignores "follows" directives in the yaml.
     ld_use_follows: bool
+    # If enabled, the end symbol for each segment will be placed before the alignment directive for the segment
+    segment_end_before_align: bool
 
     ################################################################################
     # C file options
@@ -347,6 +349,7 @@ def _parse_yaml(
         ),
         ld_wildcard_sections=p.parse_opt("ld_wildcard_sections", bool, False),
         ld_use_follows=p.parse_opt("ld_use_follows", bool, True),
+        segment_end_before_align=p.parse_opt("segment_end_before_align", bool, False),
         create_c_files=p.parse_opt("create_c_files", bool, True),
         auto_decompile_empty_functions=p.parse_opt(
             "auto_decompile_empty_functions", bool, True


### PR DESCRIPTION

* New option `segment_end_before_align`.
  * If enabled, the end symbol for each segment will be placed before the alignment directive for the segment
