### PR TITLE
Improve rodata text test, add disassemble test

### DIFF
--- a/util/symbols.py
+++ b/util/symbols.py
@@ -639,3 +639,8 @@ class Symbol:
 
     def contains_rom(self, offset):
         return offset >= self.rom and offset < self.rom_end
+
+
+def get_all_symbols():
+    global all_symbols
+    return all_symbols


### PR DESCRIPTION
This changes the rodata text test so that it has a valid result to check, and adds a test for the disassemble method. Mypy complains about `common_seg_rodata.parent` being set to a `CommonSegGroup`, so I left it as `CommonSegCode`.