### PR TITLE
has linker entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # splat Release Notes
 
+### 0.13.9
+
+* New segment option `linker_entry` (true by default).
+  * If disabled, this segment will not produce entries in the linker script.
+
 ### 0.13.8
 
 * New option `segment_end_before_align`.

--- a/segtypes/segment.py
+++ b/segtypes/segment.py
@@ -287,7 +287,6 @@ class Segment:
 
         if not ret.align:
             ret.align = parse_segment_align(yaml)
-
         return ret
 
     # For executable segments (.text); like c, asm or hasm

--- a/segtypes/segment.py
+++ b/segtypes/segment.py
@@ -223,6 +223,7 @@ class Segment:
         self.yaml = yaml
 
         self.extract: bool = True
+        self.has_linker_entry: bool = True
         if self.rom_start is None:
             self.extract = False
         elif self.type.startswith("."):
@@ -270,6 +271,7 @@ class Segment:
             ret.extract = bool(yaml.get("extract", ret.extract))
             ret.exclusive_ram_id = yaml.get("exclusive_ram_id")
             ret.given_dir = Path(yaml.get("dir", ""))
+            ret.has_linker_entry = bool(yaml.get("linker_entry", True))
         ret.given_symbol_name_format = Segment.parse_segment_symbol_name_format(yaml)
         ret.given_symbol_name_format_no_rom = (
             Segment.parse_segment_symbol_name_format_no_rom(yaml)
@@ -285,6 +287,7 @@ class Segment:
 
         if not ret.align:
             ret.align = parse_segment_align(yaml)
+
         return ret
 
     # For executable segments (.text); like c, asm or hasm
@@ -438,6 +441,9 @@ class Segment:
 
     def get_linker_entries(self) -> "List[LinkerEntry]":
         from segtypes.linker_entry import LinkerEntry
+
+        if not self.has_linker_entry:
+            return []
 
         path = self.out_path()
 

--- a/split.py
+++ b/split.py
@@ -17,11 +17,9 @@ from segtypes.linker_entry import (
     to_cname,
 )
 from segtypes.segment import Segment
-from util import compiler, log, options, palettes, symbols, relocs
+from util import log, options, palettes, symbols, relocs
 
-from util.symbols import Symbol
-
-VERSION = "0.13.8"
+VERSION = "0.13.9"
 
 parser = argparse.ArgumentParser(
     description="Split a rom given a rom, a config, and output directory"


### PR DESCRIPTION
discussed and implemented in vc, adds `linker_entry` option to subsegments, which allows you to optionally disable the emission of a linker entry for said subsegment.