### PR TITLE
Introduce DisassemblerSection and partial refactor

### DIFF
--- a/disassembler_section.py
+++ b/disassembler_section.py
@@ -83,7 +83,7 @@ class SpimdisasmDisassemberSection(DisassemblerSection):
     def __init__(self):
         self.spim_section: Optional[spimdisasm.mips.sections.SectionBase] = None
 
-    def disassemble(self):
+    def disassemble(self) -> str:
         assert self.spim_section is not None
         return self.spim_section.disassemble()
 
@@ -97,12 +97,12 @@ class SpimdisasmDisassemberSection(DisassemblerSection):
 
     def make_bss_section(
         self,
-        rom_start,
-        rom_end,
-        vram_start,
-        bss_end,
-        name,
-        segment_rom_start,
+        rom_start: int,
+        rom_end: int,
+        vram_start: int,
+        bss_end: int,
+        name: str,
+        segment_rom_start: int,
         exclusive_ram_id,
     ):
         self.spim_section = spimdisasm.mips.sections.SectionBss(
@@ -118,12 +118,12 @@ class SpimdisasmDisassemberSection(DisassemblerSection):
 
     def make_data_section(
         self,
-        rom_start,
-        rom_end,
-        vram_start,
-        name,
-        rom_bytes,
-        segment_rom_start,
+        rom_start: int,
+        rom_end: int,
+        vram_start: int,
+        name: str,
+        rom_bytes: bytes,
+        segment_rom_start: int,
         exclusive_ram_id,
     ):
         self.spim_section = spimdisasm.mips.sections.SectionData(
@@ -137,17 +137,17 @@ class SpimdisasmDisassemberSection(DisassemblerSection):
             exclusive_ram_id,
         )
 
-    def get_section(self):
+    def get_section(self) -> Optional[spimdisasm.mips.sections.SectionBase]:
         return self.spim_section
 
     def make_rodata_section(
         self,
-        rom_start,
-        rom_end,
-        vram_start,
-        name,
-        rom_bytes,
-        segment_rom_start,
+        rom_start: int,
+        rom_end: int,
+        vram_start: int,
+        name: str,
+        rom_bytes: bytes,
+        segment_rom_start: int,
         exclusive_ram_id,
     ):
         self.spim_section = spimdisasm.mips.sections.SectionRodata(
@@ -163,12 +163,12 @@ class SpimdisasmDisassemberSection(DisassemblerSection):
 
     def make_text_section(
         self,
-        rom_start,
-        rom_end,
-        vram_start,
-        name,
-        rom_bytes,
-        segment_rom_start,
+        rom_start: int,
+        rom_end: int,
+        vram_start: int,
+        name: str,
+        rom_bytes: bytes,
+        segment_rom_start: int,
         exclusive_ram_id,
     ):
         self.spim_section = spimdisasm.mips.sections.SectionText(
@@ -183,7 +183,7 @@ class SpimdisasmDisassemberSection(DisassemblerSection):
         )
 
 
-def make_disassembler_section():
+def make_disassembler_section() -> Optional[SpimdisasmDisassemberSection]:
     if options.opts.platform in ["n64", "psx", "ps2"]:
         return SpimdisasmDisassemberSection()
 
@@ -192,15 +192,16 @@ def make_disassembler_section():
 
 
 def make_text_section(
-    rom_start,
-    rom_end,
-    vram_start,
-    name,
-    rom_bytes,
-    segment_rom_start,
+    rom_start: int,
+    rom_end: int,
+    vram_start: int,
+    name: str,
+    rom_bytes: bytes,
+    segment_rom_start: int,
     exclusive_ram_id,
-):
+) -> DisassemblerSection:
     section = make_disassembler_section()
+    assert section is not None
     section.make_text_section(
         rom_start,
         rom_end,
@@ -214,15 +215,16 @@ def make_text_section(
 
 
 def make_data_section(
-    rom_start,
-    rom_end,
-    vram_start,
-    name,
-    rom_bytes,
-    segment_rom_start,
+    rom_start: int,
+    rom_end: int,
+    vram_start: int,
+    name: str,
+    rom_bytes: bytes,
+    segment_rom_start: int,
     exclusive_ram_id,
-):
+) -> DisassemblerSection:
     section = make_disassembler_section()
+    assert section is not None
     section.make_data_section(
         rom_start,
         rom_end,
@@ -236,15 +238,16 @@ def make_data_section(
 
 
 def make_rodata_section(
-    rom_start,
-    rom_end,
-    vram_start,
-    name,
-    rom_bytes,
-    segment_rom_start,
+    rom_start: int,
+    rom_end: int,
+    vram_start: int,
+    name: str,
+    rom_bytes: bytes,
+    segment_rom_start: int,
     exclusive_ram_id,
-):
+) -> DisassemblerSection:
     section = make_disassembler_section()
+    assert section is not None
     section.make_rodata_section(
         rom_start,
         rom_end,
@@ -258,15 +261,16 @@ def make_rodata_section(
 
 
 def make_bss_section(
-    rom_start,
-    rom_end,
-    vram_start,
-    bss_end,
-    name,
-    segment_rom_start,
+    rom_start: int,
+    rom_end: int,
+    vram_start: int,
+    bss_end: int,
+    name: str,
+    segment_rom_start: int,
     exclusive_ram_id,
-):
+) -> DisassemblerSection:
     section = make_disassembler_section()
+    assert section is not None
     section.make_bss_section(
         rom_start,
         rom_end,

--- a/disassembler_section.py
+++ b/disassembler_section.py
@@ -1,0 +1,279 @@
+import spimdisasm
+from util import symbols
+from typing import Optional, Set, Tuple
+from segtypes.segment import Segment
+from util import log, options, symbols
+
+
+from abc import ABC, abstractmethod
+from typing import Callable
+
+
+class DisassemblerSection(ABC):
+    @abstractmethod
+    def disassemble(self):
+        raise NotImplementedError("disassemble")
+
+    @abstractmethod
+    def analyze(self):
+        raise NotImplementedError("analyze")
+
+    @abstractmethod
+    def set_comment_offset(self, rom_start: int):
+        raise NotImplementedError("set_comment_offset")
+
+    @abstractmethod
+    def make_bss_section(
+        self,
+        rom_start,
+        rom_end,
+        vram_start,
+        bss_end,
+        name,
+        segment_rom_start,
+        exclusive_ram_id,
+    ):
+        raise NotImplementedError("make_bss_section")
+
+    @abstractmethod
+    def make_data_section(
+        self,
+        rom_start,
+        rom_end,
+        vram_start,
+        name,
+        rom_bytes,
+        segment_rom_start,
+        exclusive_ram_id,
+    ):
+        raise NotImplementedError("make_data_section")
+
+    @abstractmethod
+    def get_section(self):
+        raise NotImplementedError("get_section")
+
+    @abstractmethod
+    def make_rodata_section(
+        self,
+        rom_start,
+        rom_end,
+        vram_start,
+        name,
+        rom_bytes,
+        segment_rom_start,
+        exclusive_ram_id,
+    ):
+        raise NotImplementedError("make_rodata_section")
+
+    @abstractmethod
+    def make_text_section(
+        self,
+        rom_start,
+        rom_end,
+        vram_start,
+        name,
+        rom_bytes,
+        segment_rom_start,
+        exclusive_ram_id,
+    ):
+        raise NotImplementedError("make_text_section")
+
+
+class SpimdisasmDisassemberSection(DisassemblerSection):
+    def __init__(self):
+        self.spim_section: Optional[spimdisasm.mips.sections.SectionBase] = None
+
+    def disassemble(self):
+        assert self.spim_section is not None
+        return self.spim_section.disassemble()
+
+    def analyze(self):
+        assert self.spim_section is not None
+        self.spim_section.analyze()
+
+    def set_comment_offset(self, rom_start: int):
+        assert self.spim_section is not None
+        self.spim_section.setCommentOffset(rom_start)
+
+    def make_bss_section(
+        self,
+        rom_start,
+        rom_end,
+        vram_start,
+        bss_end,
+        name,
+        segment_rom_start,
+        exclusive_ram_id,
+    ):
+        self.spim_section = spimdisasm.mips.sections.SectionBss(
+            symbols.spim_context,
+            rom_start,
+            rom_end,
+            vram_start,
+            bss_end,
+            name,
+            segment_rom_start,
+            exclusive_ram_id,
+        )
+
+    def make_data_section(
+        self,
+        rom_start,
+        rom_end,
+        vram_start,
+        name,
+        rom_bytes,
+        segment_rom_start,
+        exclusive_ram_id,
+    ):
+        self.spim_section = spimdisasm.mips.sections.SectionData(
+            symbols.spim_context,
+            rom_start,
+            rom_end,
+            vram_start,
+            name,
+            rom_bytes,
+            segment_rom_start,
+            exclusive_ram_id,
+        )
+
+    def get_section(self):
+        return self.spim_section
+
+    def make_rodata_section(
+        self,
+        rom_start,
+        rom_end,
+        vram_start,
+        name,
+        rom_bytes,
+        segment_rom_start,
+        exclusive_ram_id,
+    ):
+        self.spim_section = spimdisasm.mips.sections.SectionRodata(
+            symbols.spim_context,
+            rom_start,
+            rom_end,
+            vram_start,
+            name,
+            rom_bytes,
+            segment_rom_start,
+            exclusive_ram_id,
+        )
+
+    def make_text_section(
+        self,
+        rom_start,
+        rom_end,
+        vram_start,
+        name,
+        rom_bytes,
+        segment_rom_start,
+        exclusive_ram_id,
+    ):
+        self.spim_section = spimdisasm.mips.sections.SectionText(
+            symbols.spim_context,
+            rom_start,
+            rom_end,
+            vram_start,
+            name,
+            rom_bytes,
+            segment_rom_start,
+            exclusive_ram_id,
+        )
+
+
+def make_disassembler_section():
+    if options.opts.platform in ["n64", "psx", "ps2"]:
+        return SpimdisasmDisassemberSection()
+
+    raise NotImplementedError("No disassembler section for requested platform")
+    return None
+
+
+def make_text_section(
+    rom_start,
+    rom_end,
+    vram_start,
+    name,
+    rom_bytes,
+    segment_rom_start,
+    exclusive_ram_id,
+):
+    section = make_disassembler_section()
+    section.make_text_section(
+        rom_start,
+        rom_end,
+        vram_start,
+        name,
+        rom_bytes,
+        segment_rom_start,
+        exclusive_ram_id,
+    )
+    return section
+
+
+def make_data_section(
+    rom_start,
+    rom_end,
+    vram_start,
+    name,
+    rom_bytes,
+    segment_rom_start,
+    exclusive_ram_id,
+):
+    section = make_disassembler_section()
+    section.make_data_section(
+        rom_start,
+        rom_end,
+        vram_start,
+        name,
+        rom_bytes,
+        segment_rom_start,
+        exclusive_ram_id,
+    )
+    return section
+
+
+def make_rodata_section(
+    rom_start,
+    rom_end,
+    vram_start,
+    name,
+    rom_bytes,
+    segment_rom_start,
+    exclusive_ram_id,
+):
+    section = make_disassembler_section()
+    section.make_rodata_section(
+        rom_start,
+        rom_end,
+        vram_start,
+        name,
+        rom_bytes,
+        segment_rom_start,
+        exclusive_ram_id,
+    )
+    return section
+
+
+def make_bss_section(
+    rom_start,
+    rom_end,
+    vram_start,
+    bss_end,
+    name,
+    segment_rom_start,
+    exclusive_ram_id,
+):
+    section = make_disassembler_section()
+    section.make_bss_section(
+        rom_start,
+        rom_end,
+        vram_start,
+        bss_end,
+        name,
+        segment_rom_start,
+        exclusive_ram_id,
+    )
+    return section

--- a/segtypes/common/bss.py
+++ b/segtypes/common/bss.py
@@ -1,7 +1,8 @@
-import spimdisasm
 from util import options, symbols, log
 
 from segtypes.common.data import CommonSegData
+
+from disassembler_section import make_bss_section
 
 
 class CommonSegBss(CommonSegData):
@@ -37,8 +38,7 @@ class CommonSegBss(CommonSegData):
             bss_end = next_subsegment.vram_start
         assert isinstance(bss_end, int), f"{self.name} {bss_end}"
 
-        self.spim_section = spimdisasm.mips.sections.SectionBss(
-            symbols.spim_context,
+        self.spim_section = make_bss_section(
             self.rom_start,
             self.rom_end,
             self.vram_start,
@@ -48,10 +48,12 @@ class CommonSegBss(CommonSegData):
             self.get_exclusive_ram_id(),
         )
 
-        self.spim_section.analyze()
-        self.spim_section.setCommentOffset(self.rom_start)
+        assert self.spim_section is not None
 
-        for spim_sym in self.spim_section.symbolList:
+        self.spim_section.analyze()
+        self.spim_section.set_comment_offset(self.rom_start)
+
+        for spim_sym in self.spim_section.get_section().symbolList:
             symbols.create_symbol_from_spim_symbol(
                 self.get_most_parent(), spim_sym.contextSym
             )

--- a/segtypes/common/c.py
+++ b/segtypes/common/c.py
@@ -153,7 +153,7 @@ class CommonSegC(CommonSegCodeSubsegment):
             self.print_file_boundaries()
 
             assert self.spim_section is not None and isinstance(
-                self.spim_section, spimdisasm.mips.sections.SectionText
+                self.spim_section.get_section(), spimdisasm.mips.sections.SectionText
             ), f"{self.name}, rom_start:{self.rom_start}, rom_end:{self.rom_end}"
 
             rodata_spim_segment = None
@@ -166,7 +166,7 @@ class CommonSegC(CommonSegCodeSubsegment):
                 ), self.rodata_sibling.type
                 if self.rodata_sibling.spim_section is not None:
                     assert isinstance(
-                        self.rodata_sibling.spim_section,
+                        self.rodata_sibling.spim_section.get_section(),
                         spimdisasm.mips.sections.SectionRodata,
                     )
                     rodata_spim_segment = self.rodata_sibling.spim_section
@@ -174,7 +174,7 @@ class CommonSegC(CommonSegCodeSubsegment):
             # Precompute function-rodata pairings
             symbols_entries = (
                 spimdisasm.mips.FunctionRodataEntry.getAllEntriesFromSections(
-                    self.spim_section, rodata_spim_segment
+                    self.spim_section.get_section(), rodata_spim_segment
                 )
             )
 

--- a/segtypes/common/codesubsegment.py
+++ b/segtypes/common/codesubsegment.py
@@ -10,6 +10,8 @@ from segtypes.common.code import CommonSegCode
 
 from segtypes.segment import Segment
 
+from disassembler_section import DisassemblerSection, make_text_section
+
 
 # abstract class for c, asm, data, etc
 class CommonSegCodeSubsegment(Segment):
@@ -24,7 +26,7 @@ class CommonSegCodeSubsegment(Segment):
             self.yaml.get("str_encoding", None) if isinstance(self.yaml, dict) else None
         )
 
-        self.spim_section: Optional[spimdisasm.mips.sections.SectionBase] = None
+        self.spim_section: Optional[DisassemblerSection] = None
         self.instr_category = rabbitizer.InstrCategory.CPU
         if options.opts.platform == "ps2":
             self.instr_category = rabbitizer.InstrCategory.R5900
@@ -56,8 +58,7 @@ class CommonSegCodeSubsegment(Segment):
                 f"Segment '{self.name}' (type '{self.type}') requires a vram address. Got '{self.vram_start}'"
             )
 
-        self.spim_section = spimdisasm.mips.sections.SectionText(
-            symbols.spim_context,
+        self.spim_section = make_text_section(
             self.rom_start,
             self.rom_end,
             self.vram_start,
@@ -67,13 +68,15 @@ class CommonSegCodeSubsegment(Segment):
             self.get_exclusive_ram_id(),
         )
 
-        self.spim_section.isHandwritten = is_hasm
-        self.spim_section.instrCat = self.instr_category
+        assert self.spim_section is not None
+
+        self.spim_section.get_section().isHandwritten = is_hasm
+        self.spim_section.get_section().instrCat = self.instr_category
 
         self.spim_section.analyze()
-        self.spim_section.setCommentOffset(self.rom_start)
+        self.spim_section.set_comment_offset(self.rom_start)
 
-        for func in self.spim_section.symbolList:
+        for func in self.spim_section.get_section().symbolList:
             assert isinstance(func, spimdisasm.mips.symbols.SymbolFunction)
 
             self.process_insns(func)
@@ -85,7 +88,7 @@ class CommonSegCodeSubsegment(Segment):
                 jtbl_label_vram, True, type="jtbl_label", define=True
             )
             sym.type = "jtbl_label"
-            symbols.add_symbol_to_spim_section(self.spim_section, sym)
+            symbols.add_symbol_to_spim_section(self.spim_section.get_section(), sym)
 
     def process_insns(
         self,
@@ -103,7 +106,7 @@ class CommonSegCodeSubsegment(Segment):
 
         # Gather symbols found by spimdisasm and create those symbols in splat's side
         for referenced_vram in func_spim.instrAnalyzer.referencedVrams:
-            context_sym = self.spim_section.getSymbol(
+            context_sym = self.spim_section.get_section().getSymbol(
                 referenced_vram, tryPlusOffset=False
             )
             if context_sym is not None:
@@ -124,7 +127,7 @@ class CommonSegCodeSubsegment(Segment):
             if instr_offset in func_spim.instrAnalyzer.symbolInstrOffset:
                 sym_address = func_spim.instrAnalyzer.symbolInstrOffset[instr_offset]
 
-                context_sym = self.spim_section.getSymbol(
+                context_sym = self.spim_section.get_section().getSymbol(
                     sym_address, tryPlusOffset=False
                 )
                 if context_sym is not None:
@@ -141,7 +144,7 @@ class CommonSegCodeSubsegment(Segment):
 
         assert isinstance(self.rom_start, int)
 
-        for in_file_offset in self.spim_section.fileBoundaries:
+        for in_file_offset in self.spim_section.get_section().fileBoundaries:
             if (in_file_offset % 16) != 0:
                 continue
 
@@ -150,8 +153,10 @@ class CommonSegCodeSubsegment(Segment):
 
                 # Look up for the last symbol in this boundary
                 sym_addr = 0
-                for sym in self.spim_section.symbolList:
-                    symOffset = sym.inFileOffset - self.spim_section.inFileOffset
+                for sym in self.spim_section.get_section().symbolList:
+                    symOffset = (
+                        sym.inFileOffset - self.spim_section.get_section().inFileOffset
+                    )
                     if in_file_offset == symOffset:
                         break
                     sym_addr = sym.vram

--- a/segtypes/common/data.py
+++ b/segtypes/common/data.py
@@ -7,6 +7,8 @@ from util import options, symbols, log
 from segtypes.common.codesubsegment import CommonSegCodeSubsegment
 from segtypes.common.group import CommonSegGroup
 
+from disassembler_section import DisassemblerSection, make_data_section
+
 
 class CommonSegData(CommonSegCodeSubsegment, CommonSegGroup):
     def out_path(self) -> Optional[Path]:
@@ -89,8 +91,7 @@ class CommonSegData(CommonSegCodeSubsegment, CommonSegGroup):
                 f"Segment '{self.name}' (type '{self.type}') requires a vram address. Got '{self.vram_start}'"
             )
 
-        self.spim_section = spimdisasm.mips.sections.SectionData(
-            symbols.spim_context,
+        self.spim_section = make_data_section(
             self.rom_start,
             self.rom_end,
             self.vram_start,
@@ -100,12 +101,14 @@ class CommonSegData(CommonSegCodeSubsegment, CommonSegGroup):
             self.get_exclusive_ram_id(),
         )
 
+        assert self.spim_section is not None
+
         self.spim_section.analyze()
-        self.spim_section.setCommentOffset(self.rom_start)
+        self.spim_section.set_comment_offset(self.rom_start)
 
         rodata_encountered = False
 
-        for symbol in self.spim_section.symbolList:
+        for symbol in self.spim_section.get_section().symbolList:
             symbols.create_symbol_from_spim_symbol(
                 self.get_most_parent(), symbol.contextSym
             )

--- a/test.py
+++ b/test.py
@@ -256,7 +256,7 @@ class Rodata(unittest.TestCase):
             rom_data.append(i)
         common_seg_rodata.disassemble_data(bytes(rom_data))
         assert common_seg_rodata.spim_section is not None
-        assert common_seg_rodata.spim_section.words[0] == 0x0010203
+        assert common_seg_rodata.spim_section.get_section().words[0] == 0x0010203
         assert symbols.get_all_symbols()[0].vram_start == 0x400
         assert symbols.get_all_symbols()[0].segment == common_seg_rodata
         assert symbols.get_all_symbols()[0].linker_section == ".rodata"
@@ -340,9 +340,13 @@ class Bss(unittest.TestCase):
         rom_bytes = bytes([0, 1, 2, 3, 4, 5, 6, 7])
         bss.disassemble_data(rom_bytes)
 
-        assert isinstance(bss.spim_section, spimdisasm.mips.sections.SectionBss)
-        assert bss.spim_section.bssVramStart == 0x40000000
-        assert bss.spim_section.bssVramEnd == 0x300
+        assert bss.spim_section is not None
+
+        assert isinstance(
+            bss.spim_section.get_section(), spimdisasm.mips.sections.SectionBss
+        )
+        assert bss.spim_section.get_section().bssVramStart == 0x40000000
+        assert bss.spim_section.get_section().bssVramEnd == 0x300
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR introduces `DisassemblerSection` to wrap `spimdisasm.mips.sections.SectionBase` and child classes. Usages of it are partially refactored. `get_section()` is used to get the underlying object to avoid doing the refactor all at once.