### PR TITLE
Add new option for pseudo move disasm.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # splat Release Notes
 
+### 0.14.1
+* New option `pseudo_move` (False by default)
+  * If enabled it will tell the disassembler to generate pseudo move instructions
+
 ### 0.14.0
 
 * Add support for PSX's GTE instruction set

--- a/disassembler/spimdisasm_disassembler.py
+++ b/disassembler/spimdisasm_disassembler.py
@@ -45,7 +45,7 @@ class SpimdisasmDisassembler(disassembler.Disassembler):
         else:
             spimdisasm.common.GlobalConfig.ENDIAN = spimdisasm.common.InputEndian.LITTLE
 
-        rabbitizer.config.pseudos_pseudoMove = False
+        rabbitizer.config.pseudos_pseudoMove = opts.pseudo_move
 
         selected_compiler = opts.compiler
         if selected_compiler == compiler.SN64:

--- a/util/options.py
+++ b/util/options.py
@@ -166,6 +166,8 @@ class SplatOpts:
     asm_generated_by: bool
     # Tells the disassembler to try disassembling functions with unknown instructions instead of falling back to disassembling as raw data
     disasm_unknown: bool
+    # Configure whether to generate the pseudo move instruction in rabbitizer
+    pseudo_move: bool
 
     ################################################################################
     # N64-specific options
@@ -412,6 +414,7 @@ def _parse_yaml(
         filesystem_path=p.parse_optional_path(base_path, "filesystem_path"),
         asm_generated_by=p.parse_opt("asm_generated_by", bool, True),
         disasm_unknown=p.parse_opt("disasm_unknown", bool, False),
+        pseudo_move=p.parse_opt("pseudo_move", bool, False),
     )
     p.check_no_unread_opts()
     return ret


### PR DESCRIPTION
This creates a new option to generate the pseudo move instructions in the disassembly. It's off by default.