### PR TITLE
Turn of the `.size` directive emitted by spimdisasm for IDO projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 0.15.3
 
-* Turn of `asm_emit_size_directive` by default for IDO projects.
+* Turned off (or maybe just "disabled") `asm_emit_size_directive` by default for IDO projects.
 
 ### 0.15.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # splat Release Notes
 
+### 0.15.3
+
+* Turn of `asm_emit_size_directive` by default for IDO projects.
+
 ### 0.15.2
+
 * Various cleanup and fixes to support more liberal use of `auto` for rom addresses
 
 ### 0.15.1
+
 * Made some modifications such that linker object paths should be simpler in some circumstances
 
 ### 0.15.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 0.15.3
 
-* Turned off (or maybe just "disabled") `asm_emit_size_directive` by default for IDO projects.
+* Disabled `asm_emit_size_directive` by default for IDO projects.
 
 ### 0.15.2
 

--- a/split.py
+++ b/split.py
@@ -19,7 +19,7 @@ from segtypes.linker_entry import (
 from segtypes.segment import Segment
 from util import log, options, palettes, symbols, relocs
 
-VERSION = "0.15.2"
+VERSION = "0.15.3"
 
 parser = argparse.ArgumentParser(
     description="Split a rom given a rom, a config, and output directory"

--- a/util/compiler.py
+++ b/util/compiler.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
@@ -11,6 +12,7 @@ class Compiler:
     c_newline: str = "\n"
     asm_inc_header: str = ""
     include_macro_inc: bool = True
+    asm_emit_size_directive: Optional[bool] = None
 
 
 GCC = Compiler(
@@ -28,7 +30,7 @@ SN64 = Compiler(
     include_macro_inc=False,
 )
 
-IDO = Compiler("IDO")
+IDO = Compiler("IDO", asm_emit_size_directive=False)
 
 compiler_for_name = {"GCC": GCC, "SN64": SN64, "IDO": IDO}
 

--- a/util/options.py
+++ b/util/options.py
@@ -289,6 +289,11 @@ def _parse_yaml(
     )
     asm_path: Path = p.parse_path(base_path, "asm_path", "asm")
 
+    asm_emit_size_directive = p.parse_optional_opt("asm_emit_size_directive", bool)
+    # If option not provided then use the compiler default
+    if asm_emit_size_directive is None:
+        asm_emit_size_directive = comp.asm_emit_size_directive
+
     def parse_endianness() -> Literal["big", "little"]:
         endianness = p.parse_opt_within(
             "endianness",
@@ -389,7 +394,7 @@ def _parse_yaml(
         ),
         asm_data_macro=p.parse_opt("asm_data_macro", str, comp.asm_data_macro),
         asm_end_label=p.parse_opt("asm_end_label", str, comp.asm_end_label),
-        asm_emit_size_directive=p.parse_optional_opt("asm_emit_size_directive", bool),
+        asm_emit_size_directive=asm_emit_size_directive,
         include_macro_inc=p.parse_opt(
             "include_macro_inc", bool, comp.include_macro_inc
         ),


### PR DESCRIPTION
Seems like asm-processor doesn't like the `.size` directive, so it seems better to disable that directive for those projects