### PR TITLE
Assign segment to user-declared symbol if rom address was provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # splat Release Notes
 
+### 0.15.4
+
+* Try to assign a segment to an user-declared symbol if the user declared the rom address.
+  * Helps to disambiguate symbols for same-address overlays.
+
 ### 0.15.3
 
 * Disabled `asm_emit_size_directive` by default for IDO projects.

--- a/split.py
+++ b/split.py
@@ -19,7 +19,7 @@ from segtypes.linker_entry import (
 from segtypes.segment import Segment
 from util import log, options, palettes, symbols, relocs
 
-VERSION = "0.15.3"
+VERSION = "0.15.4"
 
 parser = argparse.ArgumentParser(
     description="Split a rom given a rom, a config, and output directory"

--- a/util/symbols.py
+++ b/util/symbols.py
@@ -72,7 +72,9 @@ def to_cname(symbol_name: str) -> str:
     return symbol_name
 
 
-def handle_sym_addrs(path: Path, sym_addrs_lines: List[str], all_segments: "List[Segment]"):
+def handle_sym_addrs(
+    path: Path, sym_addrs_lines: List[str], all_segments: "List[Segment]"
+):
     def get_seg_for_name(name: str) -> Optional["Segment"]:
         for segment in all_segments:
             if segment.name == name:

--- a/util/symbols.py
+++ b/util/symbols.py
@@ -72,10 +72,16 @@ def to_cname(symbol_name: str) -> str:
     return symbol_name
 
 
-def handle_sym_addrs(path: Path, sym_addrs_lines: List[str], all_segments):
+def handle_sym_addrs(path: Path, sym_addrs_lines: List[str], all_segments: "List[Segment]"):
     def get_seg_for_name(name: str) -> Optional["Segment"]:
         for segment in all_segments:
             if segment.name == name:
+                return segment
+        return None
+
+    def get_seg_for_rom(rom: int) -> Optional["Segment"]:
+        for segment in all_segments:
+            if segment.contains_rom(rom):
                 return segment
         return None
 
@@ -233,6 +239,9 @@ def handle_sym_addrs(path: Path, sym_addrs_lines: List[str], all_segments):
                     )
 
                 continue
+
+            if sym.segment is None and sym.rom is not None:
+                sym.segment = get_seg_for_rom(sym.rom)
 
             if sym.segment:
                 sym.segment.add_symbol(sym)


### PR DESCRIPTION
If a symbol declared on the `symbol_addrs.txt` specifies its rom address but not a segment then try to find the corresponding segment for said symbol.
This is useful for projects with overlays that has overlapping vram addresses.
