### PR TITLE
Redundant function end detection and some other default changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * This option can also be overriden per file.
 * Disable `include_macro_inc` by default for IDO projects.
 * Disable `asm_emit_size_directive` by default for SN64 projects.
+* `spimdisasm` 1.16.0 or above is now required.
 
 ### 0.15.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # splat Release Notes
 
+### 0.16.0
+
+* Add option `detect_redundant_function_end`. It tries to detect redundant and unreferenced functions ends and merge them together.
+  * This option is ignored if the compiler is not set to IDO.
+  * This type of codegen is only affected by flags `-g`, `-g1` and `-g2`.
+  * This option can also be overriden per file.
+* Disable `include_macro_inc` by default for IDO projects.
+* Disable `asm_emit_size_directive` by default for SN64 projects.
+
 ### 0.15.4
 
 * Try to assign a segment to an user-declared symbol if the user declared the rom address.

--- a/disassembler/spimdisasm_disassembler.py
+++ b/disassembler/spimdisasm_disassembler.py
@@ -73,7 +73,9 @@ class SpimdisasmDisassembler(disassembler.Disassembler):
         elif selected_compiler == compiler.IDO:
             spimdisasm.common.GlobalConfig.COMPILER = spimdisasm.common.Compiler.IDO
 
-        spimdisasm.common.GlobalConfig.DETECT_REDUNDANT_FUNCTION_END = opts.detect_redundant_function_end
+        spimdisasm.common.GlobalConfig.DETECT_REDUNDANT_FUNCTION_END = (
+            opts.detect_redundant_function_end
+        )
 
         spimdisasm.common.GlobalConfig.GP_VALUE = opts.gp
 

--- a/disassembler/spimdisasm_disassembler.py
+++ b/disassembler/spimdisasm_disassembler.py
@@ -8,7 +8,7 @@ from typing import Set
 
 class SpimdisasmDisassembler(disassembler.Disassembler):
     # This value should be kept in sync with the version listed on requirements.txt
-    SPIMDISASM_MIN = (1, 15, 0)
+    SPIMDISASM_MIN = (1, 16, 0)
 
     def configure(self, opts: SplatOpts):
         # Configure spimdisasm
@@ -72,6 +72,8 @@ class SpimdisasmDisassembler(disassembler.Disassembler):
             spimdisasm.common.GlobalConfig.COMPILER = spimdisasm.common.Compiler.GCC
         elif selected_compiler == compiler.IDO:
             spimdisasm.common.GlobalConfig.COMPILER = spimdisasm.common.Compiler.IDO
+
+        spimdisasm.common.GlobalConfig.DETECT_REDUNDANT_FUNCTION_END = opts.detect_redundant_function_end
 
         spimdisasm.common.GlobalConfig.GP_VALUE = opts.gp
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ tqdm
 intervaltree
 colorama
 # This value should be keep in sync with the version listed on disassembler/spimdisasm_disassembler.py
-spimdisasm>=1.15.0
+spimdisasm>=1.16.0
 rabbitizer>=1.7.0
 pygfxd
 n64img>=0.1.4

--- a/segtypes/common/codesubsegment.py
+++ b/segtypes/common/codesubsegment.py
@@ -33,7 +33,11 @@ class CommonSegCodeSubsegment(Segment):
         elif options.opts.platform == "psx":
             self.instr_category = rabbitizer.InstrCategory.R3000GTE
 
-        self.detect_redundant_function_end: Optional[bool] = self.yaml.get("detect_redundant_function_end", None) if isinstance(self.yaml, dict) else None
+        self.detect_redundant_function_end: Optional[bool] = (
+            self.yaml.get("detect_redundant_function_end", None)
+            if isinstance(self.yaml, dict)
+            else None
+        )
 
     @property
     def needs_symbols(self) -> bool:
@@ -74,7 +78,9 @@ class CommonSegCodeSubsegment(Segment):
 
         self.spim_section.get_section().isHandwritten = is_hasm
         self.spim_section.get_section().instrCat = self.instr_category
-        self.spim_section.get_section().detectRedundantFunctionEnd = self.detect_redundant_function_end
+        self.spim_section.get_section().detectRedundantFunctionEnd = (
+            self.detect_redundant_function_end
+        )
 
         self.spim_section.analyze()
         self.spim_section.set_comment_offset(self.rom_start)

--- a/segtypes/common/codesubsegment.py
+++ b/segtypes/common/codesubsegment.py
@@ -33,6 +33,8 @@ class CommonSegCodeSubsegment(Segment):
         elif options.opts.platform == "psx":
             self.instr_category = rabbitizer.InstrCategory.R3000GTE
 
+        self.detect_redundant_function_end: bool = self.yaml.get("detect_redundant_function_end", False) if isinstance(self.yaml, dict) else False
+
     @property
     def needs_symbols(self) -> bool:
         return True
@@ -72,6 +74,7 @@ class CommonSegCodeSubsegment(Segment):
 
         self.spim_section.get_section().isHandwritten = is_hasm
         self.spim_section.get_section().instrCat = self.instr_category
+        self.spim_section.get_section().detectRedundantFunctionEnd = self.detect_redundant_function_end
 
         self.spim_section.analyze()
         self.spim_section.set_comment_offset(self.rom_start)

--- a/segtypes/common/codesubsegment.py
+++ b/segtypes/common/codesubsegment.py
@@ -33,7 +33,7 @@ class CommonSegCodeSubsegment(Segment):
         elif options.opts.platform == "psx":
             self.instr_category = rabbitizer.InstrCategory.R3000GTE
 
-        self.detect_redundant_function_end: bool = self.yaml.get("detect_redundant_function_end", False) if isinstance(self.yaml, dict) else False
+        self.detect_redundant_function_end: Optional[bool] = self.yaml.get("detect_redundant_function_end", None) if isinstance(self.yaml, dict) else None
 
     @property
     def needs_symbols(self) -> bool:

--- a/split.py
+++ b/split.py
@@ -19,7 +19,7 @@ from segtypes.linker_entry import (
 from segtypes.segment import Segment
 from util import log, options, palettes, symbols, relocs
 
-VERSION = "0.15.4"
+VERSION = "0.16.0"
 
 parser = argparse.ArgumentParser(
     description="Split a rom given a rom, a config, and output directory"

--- a/util/compiler.py
+++ b/util/compiler.py
@@ -31,7 +31,7 @@ SN64 = Compiler(
     asm_emit_size_directive=False,
 )
 
-IDO = Compiler("IDO", asm_emit_size_directive=False)
+IDO = Compiler("IDO", include_macro_inc=False, asm_emit_size_directive=False)
 
 compiler_for_name = {"GCC": GCC, "SN64": SN64, "IDO": IDO}
 

--- a/util/compiler.py
+++ b/util/compiler.py
@@ -28,6 +28,7 @@ SN64 = Compiler(
     asm_end_label=".end",
     c_newline="\r\n",
     include_macro_inc=False,
+    asm_emit_size_directive=False,
 )
 
 IDO = Compiler("IDO", asm_emit_size_directive=False)

--- a/util/options.py
+++ b/util/options.py
@@ -438,7 +438,9 @@ def _parse_yaml(
         filesystem_path=p.parse_optional_path(base_path, "filesystem_path"),
         asm_generated_by=p.parse_opt("asm_generated_by", bool, True),
         disasm_unknown=p.parse_opt("disasm_unknown", bool, False),
-        detect_redundant_function_end=p.parse_opt("detect_redundant_function_end", bool, True),
+        detect_redundant_function_end=p.parse_opt(
+            "detect_redundant_function_end", bool, True
+        ),
     )
     p.check_no_unread_opts()
     return ret

--- a/util/options.py
+++ b/util/options.py
@@ -175,6 +175,8 @@ class SplatOpts:
     asm_generated_by: bool
     # Tells the disassembler to try disassembling functions with unknown instructions instead of falling back to disassembling as raw data
     disasm_unknown: bool
+    # Tries to detect redundant and unreferenced functions ends and merge them together. This option is ignored if the compiler is not set to IDO.
+    detect_redundant_function_end: bool
 
     ################################################################################
     # N64-specific options
@@ -436,6 +438,7 @@ def _parse_yaml(
         filesystem_path=p.parse_optional_path(base_path, "filesystem_path"),
         asm_generated_by=p.parse_opt("asm_generated_by", bool, True),
         disasm_unknown=p.parse_opt("disasm_unknown", bool, False),
+        detect_redundant_function_end=p.parse_opt("detect_redundant_function_end", bool, True),
     )
     p.check_no_unread_opts()
     return ret


### PR DESCRIPTION
* Add option `detect_redundant_function_end`. It tries to detect redundant and unreferenced functions ends and merge them together.
  * This option is ignored if the compiler is not set to IDO.
  * This type of codegen is only affected by flags `-g`, `-g1` and `-g2`.
  * This option can also be overriden per file.
* Disable `include_macro_inc` by default for IDO projects.
* Disable `asm_emit_size_directive` by default for SN64 projects.
* `spimdisasm` 1.16.0 or above is now required.