### PR TITLE
Option to still disassemble matched functions and migrated data

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,13 +1,13 @@
-name: mypy
+name: black
 
 on:
   push:
   pull_request:
 
 jobs:
-  mypy_checks:
+  black_checks:
     runs-on: ubuntu-latest
-    name: mypy
+    name: black
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.8
@@ -16,8 +16,8 @@ jobs:
         python-version: 3.8
     - name: Install Dependencies
       run: |
-        pip install mypy
+        pip install black
         pip install -r requirements.txt
         pip install types-PyYAML
-    - name: mypy
-      run: mypy --show-column-numbers --hide-error-context .
+    - name: black
+      run: black --check .

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,20 @@
+name: unit_tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  unit_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install Dependencies
+        run: pip install -r requirements.txt
+      - name: Run unit tests
+        run: sh run_tests.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 0.16.2
 
-* Add option `disassembly_all`. If enabled then already matched functions and migrated data will be disassembled to files anyways.
+* Add option `disassemble_all`. If enabled then already matched functions and migrated data will be disassembled to files anyways.
 
 ### 0.16.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # splat Release Notes
 
+### 0.16.2
+
+* Add option `disassembly_all`. If enabled then already matched functions and migrated data will be disassembled to files anyways.
+
 ### 0.16.1
+
 * Various changes so that series of image and palette subsegments can have `auto` rom addresses (as long as the first can find its rom address from the parent segment or its own definition)
 
 ### 0.16.0

--- a/segtypes/common/c.py
+++ b/segtypes/common/c.py
@@ -197,6 +197,7 @@ class CommonSegC(CommonSegCodeSubsegment):
                     if (
                         entry.function.getName() in self.global_asm_funcs
                         or is_new_c_file
+                        or options.opts.disassembly_all
                     ):
                         func_sym = self.get_symbol(
                             entry.function.vram,
@@ -212,6 +213,7 @@ class CommonSegC(CommonSegCodeSubsegment):
                         if (
                             spim_rodata_sym.getName() in self.global_asm_rodata_syms
                             or is_new_c_file
+                            or options.opts.disassembly_all
                         ):
                             rodata_sym = self.get_symbol(
                                 spim_rodata_sym.vram, in_segment=True, local_only=True

--- a/segtypes/common/c.py
+++ b/segtypes/common/c.py
@@ -197,7 +197,7 @@ class CommonSegC(CommonSegCodeSubsegment):
                     if (
                         entry.function.getName() in self.global_asm_funcs
                         or is_new_c_file
-                        or options.opts.disassembly_all
+                        or options.opts.disassemble_all
                     ):
                         func_sym = self.get_symbol(
                             entry.function.vram,
@@ -213,7 +213,7 @@ class CommonSegC(CommonSegCodeSubsegment):
                         if (
                             spim_rodata_sym.getName() in self.global_asm_rodata_syms
                             or is_new_c_file
-                            or options.opts.disassembly_all
+                            or options.opts.disassemble_all
                         ):
                             rodata_sym = self.get_symbol(
                                 spim_rodata_sym.vram, in_segment=True, local_only=True

--- a/segtypes/common/data.py
+++ b/segtypes/common/data.py
@@ -38,7 +38,7 @@ class CommonSegData(CommonSegCodeSubsegment, CommonSegGroup):
     def split(self, rom_bytes: bytes):
         super().split(rom_bytes)
 
-        if self.type.startswith(".") and not options.opts.disassembly_all:
+        if self.type.startswith(".") and not options.opts.disassemble_all:
             return
 
         if self.spim_section is None or not self.should_self_split():

--- a/segtypes/common/data.py
+++ b/segtypes/common/data.py
@@ -31,26 +31,29 @@ class CommonSegData(CommonSegCodeSubsegment, CommonSegGroup):
     def split(self, rom_bytes: bytes):
         super().split(rom_bytes)
 
-        if (
-            not self.type.startswith(".")
-            and self.spim_section
-            and self.should_self_split()
-        ):
-            path = self.out_path()
+        if self.type.startswith(".") and not options.opts.disassembly_all:
+            return
 
-            if path:
-                path.parent.mkdir(parents=True, exist_ok=True)
+        if self.spim_section is None or not self.should_self_split():
+            return
 
-                self.print_file_boundaries()
+        path = self.out_path()
 
-                with open(path, "w", newline="\n") as f:
-                    f.write('.include "macro.inc"\n\n')
-                    preamble = options.opts.generated_s_preamble
-                    if preamble:
-                        f.write(preamble + "\n")
-                    f.write(f".section {self.get_linker_section()}\n\n")
+        if path is None:
+            return
 
-                    f.write(self.spim_section.disassemble())
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        self.print_file_boundaries()
+
+        with open(path, "w", newline="\n") as f:
+            f.write('.include "macro.inc"\n\n')
+            preamble = options.opts.generated_s_preamble
+            if preamble:
+                f.write(preamble + "\n")
+            f.write(f".section {self.get_linker_section()}\n\n")
+
+            f.write(self.spim_section.disassemble())
 
     def should_self_split(self) -> bool:
         return options.opts.is_mode_active("data")

--- a/split.py
+++ b/split.py
@@ -19,7 +19,7 @@ from segtypes.linker_entry import (
 from segtypes.segment import Segment
 from util import log, options, palettes, symbols, relocs
 
-VERSION = "0.16.1"
+VERSION = "0.16.2"
 
 parser = argparse.ArgumentParser(
     description="Split a rom given a rom, a config, and output directory"

--- a/util/options.py
+++ b/util/options.py
@@ -177,6 +177,8 @@ class SplatOpts:
     disasm_unknown: bool
     # Tries to detect redundant and unreferenced functions ends and merge them together. This option is ignored if the compiler is not set to IDO.
     detect_redundant_function_end: bool
+    # Don't skip disassembling already matched functions and migrated sections
+    disassembly_all: bool
 
     ################################################################################
     # N64-specific options
@@ -441,6 +443,7 @@ def _parse_yaml(
         detect_redundant_function_end=p.parse_opt(
             "detect_redundant_function_end", bool, True
         ),
+        disassembly_all = p.parse_opt("disassembly_all", bool, False),
     )
     p.check_no_unread_opts()
     return ret

--- a/util/options.py
+++ b/util/options.py
@@ -443,7 +443,7 @@ def _parse_yaml(
         detect_redundant_function_end=p.parse_opt(
             "detect_redundant_function_end", bool, True
         ),
-        disassemble_all = p.parse_opt("disassemble_all", bool, False),
+        disassemble_all=p.parse_opt("disassemble_all", bool, False),
     )
     p.check_no_unread_opts()
     return ret

--- a/util/options.py
+++ b/util/options.py
@@ -178,7 +178,7 @@ class SplatOpts:
     # Tries to detect redundant and unreferenced functions ends and merge them together. This option is ignored if the compiler is not set to IDO.
     detect_redundant_function_end: bool
     # Don't skip disassembling already matched functions and migrated sections
-    disassembly_all: bool
+    disassemble_all: bool
 
     ################################################################################
     # N64-specific options
@@ -443,7 +443,7 @@ def _parse_yaml(
         detect_redundant_function_end=p.parse_opt(
             "detect_redundant_function_end", bool, True
         ),
-        disassembly_all = p.parse_opt("disassembly_all", bool, False),
+        disassemble_all = p.parse_opt("disassemble_all", bool, False),
     )
     p.check_no_unread_opts()
     return ret


### PR DESCRIPTION
Add option `disassemble_all`. If enabled then already matched functions and migrated data will be disassembled to files anyways.

This option can be useful to inspect the assembly of already matched stuff.