### PR TITLE
Option to generate makerom-compatible segment symbols in the linker script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # splat Release Notes
 
+### 0.16.4
+
+* Add option `segment_symbols_style`.
+  * Allows changing the style of the generated segment symbols in the linker script.
+  * Possible values:
+    * `splat`: The current style for segment symbols.
+    * `makerom`: Style that aims to be compatible with makerom generated symbols.
+  * Defaults to `splat`.
+
 ### 0.16.3
 
 * Add `--stdout-only` flag. Redirects the progress bar output to `stdout` instead of `stderr`.

--- a/segtypes/linker_entry.py
+++ b/segtypes/linker_entry.py
@@ -69,32 +69,32 @@ def segment_cname(segment: Segment) -> str:
 
 
 def get_segment_rom_start(cname: str) -> str:
-    if options.opts.segment_symbol_style == "makerom":
+    if options.opts.segment_symbols_style == "makerom":
         return f"_{cname}SegmentRomStart"
     return f"{cname}_ROM_START"
 
 
 def get_segment_rom_end(cname: str) -> str:
-    if options.opts.segment_symbol_style == "makerom":
+    if options.opts.segment_symbols_style == "makerom":
         return f"_{cname}SegmentRomEnd"
     return f"{cname}_ROM_END"
 
 
 def get_segment_vram_start(cname: str) -> str:
-    if options.opts.segment_symbol_style == "makerom":
+    if options.opts.segment_symbols_style == "makerom":
         return f"_{cname}SegmentStart"
     return f"{cname}_VRAM"
 
 
 def get_segment_vram_end(cname: str) -> str:
-    if options.opts.segment_symbol_style == "makerom":
+    if options.opts.segment_symbols_style == "makerom":
         return f"_{cname}SegmentEnd"
     return f"{cname}_VRAM_END"
 
 
 def convert_section_name_to_linker_format(section_type: str) -> str:
     assert section_type.startswith(".")
-    if options.opts.segment_symbol_style == "makerom":
+    if options.opts.segment_symbols_style == "makerom":
         if section_type == ".rodata":
             return "RoData"
         return section_type[1:].capitalize()
@@ -104,21 +104,21 @@ def convert_section_name_to_linker_format(section_type: str) -> str:
 
 def get_segment_section_start(segment_name: str, section_type: str) -> str:
     sec = convert_section_name_to_linker_format(section_type)
-    if options.opts.segment_symbol_style == "makerom":
+    if options.opts.segment_symbols_style == "makerom":
         return f"_{segment_name}Segment{sec}Start"
     return f"{segment_name}{sec}_START"
 
 
 def get_segment_section_end(segment_name: str, section_type: str) -> str:
     sec = convert_section_name_to_linker_format(section_type)
-    if options.opts.segment_symbol_style == "makerom":
+    if options.opts.segment_symbols_style == "makerom":
         return f"_{segment_name}Segment{sec}End"
     return f"{segment_name}{sec}_END"
 
 
 def get_segment_section_size(segment_name: str, section_type: str) -> str:
     sec = convert_section_name_to_linker_format(section_type)
-    if options.opts.segment_symbol_style == "makerom":
+    if options.opts.segment_symbols_style == "makerom":
         return f"_{segment_name}Segment{sec}Size"
     return f"{segment_name}{sec}_SIZE"
 

--- a/segtypes/linker_entry.py
+++ b/segtypes/linker_entry.py
@@ -73,20 +73,24 @@ def get_segment_rom_start(cname: str) -> str:
         return f"_{cname}SegmentRomStart"
     return f"{cname}_ROM_START"
 
+
 def get_segment_rom_end(cname: str) -> str:
     if options.opts.segment_symbol_style == "makerom":
         return f"_{cname}SegmentRomEnd"
     return f"{cname}_ROM_END"
+
 
 def get_segment_vram_start(cname: str) -> str:
     if options.opts.segment_symbol_style == "makerom":
         return f"_{cname}SegmentStart"
     return f"{cname}_VRAM"
 
+
 def get_segment_vram_end(cname: str) -> str:
     if options.opts.segment_symbol_style == "makerom":
         return f"_{cname}SegmentEnd"
     return f"{cname}_VRAM_END"
+
 
 def convert_section_name_to_linker_format(section_type: str) -> str:
     assert section_type.startswith(".")
@@ -97,11 +101,13 @@ def convert_section_name_to_linker_format(section_type: str) -> str:
 
     return to_cname(section_type.upper())
 
+
 def get_segment_section_start(segment_name: str, section_type: str) -> str:
     sec = convert_section_name_to_linker_format(section_type)
     if options.opts.segment_symbol_style == "makerom":
         return f"_{segment_name}Segment{sec}Start"
     return f"{segment_name}{sec}_START"
+
 
 def get_segment_section_end(segment_name: str, section_type: str) -> str:
     sec = convert_section_name_to_linker_format(section_type)
@@ -109,11 +115,13 @@ def get_segment_section_end(segment_name: str, section_type: str) -> str:
         return f"_{segment_name}Segment{sec}End"
     return f"{segment_name}{sec}_END"
 
+
 def get_segment_section_size(segment_name: str, section_type: str) -> str:
     sec = convert_section_name_to_linker_format(section_type)
     if options.opts.segment_symbol_style == "makerom":
         return f"_{segment_name}Segment{sec}Size"
     return f"{segment_name}{sec}_SIZE"
+
 
 def get_segment_vram_end_symbol_name(segment: Segment) -> str:
     return get_segment_vram_end(segment_cname(segment))
@@ -247,7 +255,9 @@ class LinkerWriter:
 
                     if not (entering_bss or leaving_bss):
                         # Don't write a START symbol if we are about to end the section
-                        section_start = get_segment_section_start(seg_name, entry.section_type)
+                        section_start = get_segment_section_start(
+                            seg_name, entry.section_type
+                        )
                         self._write_symbol(section_start, ".")
                         section_labels[entry.section_type].started = True
 
@@ -273,7 +283,9 @@ class LinkerWriter:
                     entry in last_seen_sections
                     and section_labels[entry.section_type].started
                 ):
-                    self._end_section(seg_name, last_seen_sections[entry], section_labels)
+                    self._end_section(
+                        seg_name, last_seen_sections[entry], section_labels
+                    )
 
                 self._end_block()
 
@@ -438,7 +450,12 @@ class LinkerWriter:
 
         self._writeln("")
 
-    def _end_section(self, seg_name: str, cur_section: str, section_labels: OrderedDict[str, LinkerSection]) -> None:
+    def _end_section(
+        self,
+        seg_name: str,
+        cur_section: str,
+        section_labels: OrderedDict[str, LinkerSection],
+    ) -> None:
         section_start = get_segment_section_start(seg_name, cur_section)
         section_end = get_segment_section_end(seg_name, cur_section)
         section_size = get_segment_section_size(seg_name, cur_section)

--- a/segtypes/linker_entry.py
+++ b/segtypes/linker_entry.py
@@ -69,43 +69,51 @@ def segment_cname(segment: Segment) -> str:
 
 
 def get_segment_rom_start(cname: str) -> str:
+    if options.opts.segment_symbol_style == "makerom":
+        return f"_{cname}SegmentRomStart"
     return f"{cname}_ROM_START"
-    return f"_{cname}SegmentRomStart"
 
 def get_segment_rom_end(cname: str) -> str:
+    if options.opts.segment_symbol_style == "makerom":
+        return f"_{cname}SegmentRomEnd"
     return f"{cname}_ROM_END"
-    return f"_{cname}SegmentRomEnd"
 
 def get_segment_vram_start(cname: str) -> str:
+    if options.opts.segment_symbol_style == "makerom":
+        return f"_{cname}SegmentStart"
     return f"{cname}_VRAM"
-    return f"_{cname}SegmentStart"
 
 def get_segment_vram_end(cname: str) -> str:
+    if options.opts.segment_symbol_style == "makerom":
+        return f"_{cname}SegmentEnd"
     return f"{cname}_VRAM_END"
-    return f"_{cname}SegmentEnd"
 
 def convert_section_name_to_linker_format(section_type: str) -> str:
     assert section_type.startswith(".")
+    if options.opts.segment_symbol_style == "makerom":
+        if section_type == ".rodata":
+            return "RoData"
+        return section_type[1:].capitalize()
 
     return to_cname(section_type.upper())
-    if section_type == ".rodata":
-        return "RoData"
-    return section_type[1:].capitalize()
 
 def get_segment_section_start(segment_name: str, section_type: str) -> str:
     sec = convert_section_name_to_linker_format(section_type)
+    if options.opts.segment_symbol_style == "makerom":
+        return f"_{segment_name}Segment{sec}Start"
     return f"{segment_name}{sec}_START"
-    return f"_{segment_name}Segment{sec}Start"
 
 def get_segment_section_end(segment_name: str, section_type: str) -> str:
     sec = convert_section_name_to_linker_format(section_type)
+    if options.opts.segment_symbol_style == "makerom":
+        return f"_{segment_name}Segment{sec}End"
     return f"{segment_name}{sec}_END"
-    return f"_{segment_name}Segment{sec}End"
 
 def get_segment_section_size(segment_name: str, section_type: str) -> str:
     sec = convert_section_name_to_linker_format(section_type)
+    if options.opts.segment_symbol_style == "makerom":
+        return f"_{segment_name}Segment{sec}Size"
     return f"{segment_name}{sec}_SIZE"
-    return f"_{segment_name}Segment{sec}Size"
 
 def get_segment_vram_end_symbol_name(segment: Segment) -> str:
     return get_segment_vram_end(segment_cname(segment))

--- a/split.py
+++ b/split.py
@@ -20,7 +20,7 @@ from segtypes.linker_entry import (
 from segtypes.segment import Segment
 from util import log, options, palettes, symbols, relocs
 
-VERSION = "0.16.3"
+VERSION = "0.16.4"
 
 parser = argparse.ArgumentParser(
     description="Split a rom given a rom, a config, and output directory"

--- a/util/options.py
+++ b/util/options.py
@@ -104,6 +104,8 @@ class SplatOpts:
     ld_use_follows: bool
     # If enabled, the end symbol for each segment will be placed before the alignment directive for the segment
     segment_end_before_align: bool
+    # 
+    segment_symbol_style: str
 
     ################################################################################
     # C file options
@@ -374,6 +376,7 @@ def _parse_yaml(
         ld_wildcard_sections=p.parse_opt("ld_wildcard_sections", bool, False),
         ld_use_follows=p.parse_opt("ld_use_follows", bool, True),
         segment_end_before_align=p.parse_opt("segment_end_before_align", bool, False),
+        segment_symbol_style=p.parse_opt_within("segment_symbol_style", str, ["splat", "makerom"], "splat"),
         create_c_files=p.parse_opt("create_c_files", bool, True),
         auto_decompile_empty_functions=p.parse_opt(
             "auto_decompile_empty_functions", bool, True

--- a/util/options.py
+++ b/util/options.py
@@ -104,7 +104,7 @@ class SplatOpts:
     ld_use_follows: bool
     # If enabled, the end symbol for each segment will be placed before the alignment directive for the segment
     segment_end_before_align: bool
-    # 
+    #
     segment_symbol_style: str
 
     ################################################################################
@@ -376,7 +376,9 @@ def _parse_yaml(
         ld_wildcard_sections=p.parse_opt("ld_wildcard_sections", bool, False),
         ld_use_follows=p.parse_opt("ld_use_follows", bool, True),
         segment_end_before_align=p.parse_opt("segment_end_before_align", bool, False),
-        segment_symbol_style=p.parse_opt_within("segment_symbol_style", str, ["splat", "makerom"], "splat"),
+        segment_symbol_style=p.parse_opt_within(
+            "segment_symbol_style", str, ["splat", "makerom"], "splat"
+        ),
         create_c_files=p.parse_opt("create_c_files", bool, True),
         auto_decompile_empty_functions=p.parse_opt(
             "auto_decompile_empty_functions", bool, True

--- a/util/options.py
+++ b/util/options.py
@@ -104,8 +104,8 @@ class SplatOpts:
     ld_use_follows: bool
     # If enabled, the end symbol for each segment will be placed before the alignment directive for the segment
     segment_end_before_align: bool
-    #
-    segment_symbol_style: str
+    # Controls the style of the auto-generated segment symbols in the linker script. Possible values: splat, makerom
+    segment_symbols_style: str
 
     ################################################################################
     # C file options
@@ -376,8 +376,8 @@ def _parse_yaml(
         ld_wildcard_sections=p.parse_opt("ld_wildcard_sections", bool, False),
         ld_use_follows=p.parse_opt("ld_use_follows", bool, True),
         segment_end_before_align=p.parse_opt("segment_end_before_align", bool, False),
-        segment_symbol_style=p.parse_opt_within(
-            "segment_symbol_style", str, ["splat", "makerom"], "splat"
+        segment_symbols_style=p.parse_opt_within(
+            "segment_symbols_style", str, ["splat", "makerom"], "splat"
         ),
         create_c_files=p.parse_opt("create_c_files", bool, True),
         auto_decompile_empty_functions=p.parse_opt(


### PR DESCRIPTION
The new option `segment_symbols_style` can be set to generate makerom compatible segment symbols instead of the current style used by splat for segment symbols.