### PR TITLE
Add `get_section_flags` method to `Segment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 0.16.4
 
-* Add `get_linker_section_flags` method to the `Segment` class.
+* Add `get_section_flags` method to the `Segment` class.
   * Useful for providing linker section flags when creating a custom section when making splat extensions.
   * This may be necessary for some custom section types, because sections unrecognized by the linker will not link its data properly.
   * More info about section flags: <https://sourceware.org/binutils/docs/as/Section.html#ELF-Version>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # splat Release Notes
 
+### 0.16.4
+
+* Add `get_linker_section_flags` method to the `Segment` class.
+  * Useful for providing linker section flags when creating a custom section when making splat extensions.
+  * This may be necessary for some custom section types, because sections unrecognized by the linker will not link its data properly.
+  * More info about section flags: <https://sourceware.org/binutils/docs/as/Section.html#ELF-Version>
+
 ### 0.16.3
 
 * Add `--stdout-only` flag. Redirects the progress bar output to `stdout` instead of `stderr`.

--- a/segtypes/common/data.py
+++ b/segtypes/common/data.py
@@ -57,7 +57,7 @@ class CommonSegData(CommonSegCodeSubsegment, CommonSegGroup):
                 f.write(preamble + "\n")
 
             f.write(f".section {self.get_linker_section()}")
-            section_flags = self.get_linker_section_flags()
+            section_flags = self.get_section_flags()
             if section_flags:
                 f.write(f', "{section_flags}"')
             f.write("\n\n")

--- a/segtypes/common/data.py
+++ b/segtypes/common/data.py
@@ -55,7 +55,12 @@ class CommonSegData(CommonSegCodeSubsegment, CommonSegGroup):
             preamble = options.opts.generated_s_preamble
             if preamble:
                 f.write(preamble + "\n")
-            f.write(f".section {self.get_linker_section()}\n\n")
+
+            f.write(f".section {self.get_linker_section()}")
+            section_flags = self.get_linker_section_flags()
+            if section_flags:
+                f.write(f', "{section_flags}"')
+            f.write("\n\n")
 
             f.write(self.spim_section.disassemble())
 

--- a/segtypes/segment.py
+++ b/segtypes/segment.py
@@ -428,6 +428,9 @@ class Segment:
     def get_linker_section(self) -> str:
         return ".data"
 
+    def get_linker_section_flags(self) -> Optional[str]:
+        return None
+
     def out_path(self) -> Optional[Path]:
         return None
 

--- a/segtypes/segment.py
+++ b/segtypes/segment.py
@@ -428,7 +428,22 @@ class Segment:
     def get_linker_section(self) -> str:
         return ".data"
 
-    def get_linker_section_flags(self) -> Optional[str]:
+    def get_section_flags(self) -> Optional[str]:
+        """
+        Allows specifying flags for a section.
+
+        This can be useful when creating a custom section, since sections not recognized by the linker will not be linked properly.
+
+        GNU as docs about the section directive and flags: https://sourceware.org/binutils/docs/as/Section.html#ELF-Version
+
+        Example:
+
+        ```
+        def get_section_flags(self) -> Optional[str]:
+            # Tells the linker to allocate this section
+            return "a"
+        ```
+        """
         return None
 
     def out_path(self) -> Optional[Path]:

--- a/split.py
+++ b/split.py
@@ -20,7 +20,7 @@ from segtypes.linker_entry import (
 from segtypes.segment import Segment
 from util import log, options, palettes, symbols, relocs
 
-VERSION = "0.16.3"
+VERSION = "0.16.4"
 
 parser = argparse.ArgumentParser(
     description="Split a rom given a rom, a config, and output directory"


### PR DESCRIPTION
I added this because I stumbled with the fact custom sections don't get linked properly if they don't have the proper flags.

Really there's no real need to have this on splat's side, but I think it would be cleaner to use let splat extensions to use this method instead of requiring them to duplicate the code of the `split` method with a small modification.

GAS docs for the section directive: https://sourceware.org/binutils/docs/as/Section.html#ELF-Version