### PR TITLE
Fix align in code segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # splat Release Notes
 
+### 0.16.8
+
+* Avoid ignoring the `align` defined in a segment for `code` segments
+
 ### 0.16.7
 
 * Use `pylibyaml` to speed-up yaml parsing

--- a/segtypes/common/code.py
+++ b/segtypes/common/code.py
@@ -7,7 +7,7 @@ from util.range import Range
 from util.symbols import Symbol
 
 from segtypes.common.group import CommonSegGroup
-from segtypes.segment import Segment
+from segtypes.segment import Segment, parse_segment_align
 
 CODE_TYPES = ["c", "asm", "hasm"]
 
@@ -44,7 +44,10 @@ class CommonSegCode(CommonSegGroup):
         self.jtbl_glabels_to_add: Set[int] = set()
         self.jumptables: Dict[int, Tuple[int, int]] = {}
         self.rodata_syms: Dict[int, List[Symbol]] = {}
-        self.align = 0x10
+
+        self.align = parse_segment_align(yaml)
+        if self.align is None:
+            self.align = 0x10
 
     @property
     def needs_symbols(self) -> bool:

--- a/split.py
+++ b/split.py
@@ -24,7 +24,7 @@ from segtypes.linker_entry import (
 from segtypes.segment import Segment
 from util import log, options, palettes, symbols, relocs
 
-VERSION = "0.16.7"
+VERSION = "0.16.8"
 
 parser = argparse.ArgumentParser(
     description="Split a rom given a rom, a config, and output directory"


### PR DESCRIPTION
The `align` set in a yaml for `code` segments was being ignored and being set unconditionally to `0x10