### PR TITLE
disassemble-all command line argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # splat Release Notes
 
 ### 0.16.9
-* Add command line argument `disassemble-all`, which has the same effect as the `disassemble_all` yaml option so will disamble already matched functions as well as migrated data.
+* Add command line argument `--disassemble-all`, which has the same effect as the `disassemble_all` yaml option so will disamble already matched functions as well as migrated data.
   * Note: the command line argument takes precedence over the yaml, so will take effect even if the yaml option is set to false.
 
 ### 0.16.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # splat Release Notes
 
+### 0.16.8
+
+* Add command line argument `disassemble-all`, which has the same effect as the `disassemble_all` yaml option so will disamble already matched functions as well as migrated data.
+  * Note: the command line argument takes precedence over the yaml, so will take effect even if the yaml option is set to false.
+
 ### 0.16.7
 
 * Use `pylibyaml` to speed-up yaml parsing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # splat Release Notes
 
 ### 0.16.9
+
 * Add command line argument `--disassemble-all`, which has the same effect as the `disassemble_all` yaml option so will disamble already matched functions as well as migrated data.
   * Note: the command line argument takes precedence over the yaml, so will take effect even if the yaml option is set to false.
 

--- a/split.py
+++ b/split.py
@@ -44,7 +44,9 @@ parser.add_argument(
     "--stdout-only", help="Print all output to stdout", action="store_true"
 )
 parser.add_argument(
-    "--disassemble-all", help="Disasemble matched functions and migrated data", action="store_true"
+    "--disassemble-all",
+    help="Disasemble matched functions and migrated data",
+    action="store_true",
 )
 
 linker_writer: LinkerWriter

--- a/split.py
+++ b/split.py
@@ -43,6 +43,9 @@ parser.add_argument(
 parser.add_argument(
     "--stdout-only", help="Print all output to stdout", action="store_true"
 )
+parser.add_argument(
+    "--disassemble-all", help="Disasemble matched functions and migrated data", action="store_true"
+)
 
 linker_writer: LinkerWriter
 config: Dict[str, Any]
@@ -224,6 +227,7 @@ def main(
     use_cache=True,
     skip_version_check=False,
     stdout_only=False,
+    disassemble_all=False,
 ):
     global config
 
@@ -237,7 +241,7 @@ def main(
             additional_config = yaml.load(f.read(), Loader=yaml.SafeLoader)
         config = merge_configs(config, additional_config)
 
-    options.initialize(config, config_path, modes, verbose)
+    options.initialize(config, config_path, modes, verbose, disassemble_all)
 
     disassembler_instance.create_disassembler_instance(options.opts.platform)
     disassembler_instance.get_instance().check_version(skip_version_check, VERSION)
@@ -496,4 +500,5 @@ if __name__ == "__main__":
         args.use_cache,
         args.skip_version_check,
         args.stdout_only,
+        args.disassemble_all,
     )

--- a/split.py
+++ b/split.py
@@ -24,7 +24,7 @@ from segtypes.linker_entry import (
 from segtypes.segment import Segment
 from util import log, options, palettes, symbols, relocs
 
-VERSION = "0.16.7"
+VERSION = "0.16.8"
 
 parser = argparse.ArgumentParser(
     description="Split a rom given a rom, a config, and output directory"

--- a/util/options.py
+++ b/util/options.py
@@ -453,7 +453,9 @@ def _parse_yaml(
             "detect_redundant_function_end", bool, True
         ),
         # Command line argument takes precedence over yaml option
-        disassemble_all = disasm_all if disasm_all else p.parse_opt("disassemble_all", bool, False),
+        disassemble_all=disasm_all
+        if disasm_all
+        else p.parse_opt("disassemble_all", bool, False),
     )
     p.check_no_unread_opts()
     return ret

--- a/util/options.py
+++ b/util/options.py
@@ -285,6 +285,7 @@ def _parse_yaml(
     config_paths: List[str],
     modes: List[str],
     verbose: bool = False,
+    disasm_all: bool = False,
 ) -> SplatOpts:
     p = OptParser(yaml)
 
@@ -451,7 +452,8 @@ def _parse_yaml(
         detect_redundant_function_end=p.parse_opt(
             "detect_redundant_function_end", bool, True
         ),
-        disassemble_all=p.parse_opt("disassemble_all", bool, False),
+        # Command line argument takes precedence over yaml option
+        disassemble_all = disasm_all if disasm_all else p.parse_opt("disassemble_all", bool, False),
     )
     p.check_no_unread_opts()
     return ret
@@ -462,10 +464,11 @@ def initialize(
     config_paths: List[str],
     modes: Optional[List[str]] = None,
     verbose=False,
+    disasm_all=False,
 ):
     global opts
 
     if not modes:
         modes = ["all"]
 
-    opts = _parse_yaml(config["options"], config_paths, modes, verbose)
+    opts = _parse_yaml(config["options"], config_paths, modes, verbose, disasm_all)


### PR DESCRIPTION
Adds disassemble-all as a command line argument for easier use in Makefiles. This keeps the yaml option as well, though does give precedence to the command line arg so will still disassemble everything even if the option is set to false in the yaml.