### PR TITLE
Implement PSX-EXE parsing in `create_config.py`

### DIFF
--- a/create_config.py
+++ b/create_config.py
@@ -221,7 +221,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x{exe.initial_gp:08X}
 
-  use_o_as_suffix: True
+  o_as_suffix: True
   use_legacy_include_asm: False
 
   asm_function_macro: glabel
@@ -255,7 +255,7 @@ segments:
   - name: main
     type: code
     start: 0x800
-    vram: 0x{exe.text_vram:X}
+    vram: 0x{exe.destination_vram:X}
     bss_size: 0x{exe.bss_size:X}
     subsegments:
 """
@@ -268,32 +268,20 @@ segments:
       - [0x{text_offset:X}, asm, {text_offset:X}]
 """
 
-    section_end = text_offset + exe.text_size
-    if exe.data_size != 0:
+    if exe.data_vram != 0 and exe.data_size != 0:
+        data_offset = exe.data_offset
         segments += f"""\
-      - [0x{section_end:X}, data, {section_end:X}]
+      - [0x{data_offset:X}, data, {data_offset:X}]
 """
-        section_end += exe.data_size
 
     if exe.bss_size != 0:
         segments += f"""\
-      - {{ start: 0x{section_end:X}, type: bss, name: {section_end:X}, vram: 0x{exe.bss_vram:X} }}
-"""
-        section_end += exe.bss_size
-
-    if section_end != exe.size:
-        segments += f"""\
-
-  - type: bin
-    start: 0x{section_end:X}
-    follows_vram: main
+      - {{ start: 0x{exe.size:X}, type: bss, name: {exe.bss_vram:X}, vram: 0x{exe.bss_vram:X} }}
 """
 
     segments += f"""\
   - [0x{exe.size:X}]
 """
-
-    print(header + segments)
 
     out_file = f"{basename}.yaml"
     with open(out_file, "w", newline="\n") as f:

--- a/create_config.py
+++ b/create_config.py
@@ -246,13 +246,6 @@ options:
   data_string_guesser_level: 2
 """
 
-    print(exe)
-    print(f"{exe.initial_pc:X}")
-    print(f"{exe.text_vram:X}")
-    print(f"{exe.initial_sp_base:X}")
-    print(f"{exe.initial_gp:X}")
-
-
     segments = f"""\
 segments:
   - name: header

--- a/create_config.py
+++ b/create_config.py
@@ -35,8 +35,7 @@ def main(file_path: Path):
         create_gc_config(file_path, file_bytes)
         return
 
-    psx_exe_header = file_bytes[0:8].decode()
-    if psx_exe_header == "PS-X EXE":
+    if file_bytes[0:8] == b"PS-X EXE":
         create_psx_config(file_path, file_bytes)
         return
 

--- a/create_config.py
+++ b/create_config.py
@@ -54,24 +54,48 @@ options:
   basename: {basename}
   target_path: {rom_path.with_suffix(".z64")}
   base_path: .
+  platform: n64
   compiler: {rom.compiler}
+
+  asm_path: asm
+  src_path: src
+  build_path: build
+  # create_asm_dependencies: True
+
+  ld_script_path: {basename}.ld
+
   find_file_boundaries: True
   header_encoding: {rom.header_encoding}
-  platform: n64
-  # undefined_funcs_auto: True
-  # undefined_funcs_auto_path: undefined_funcs_auto.txt
-  # undefined_syms_auto: True
-  # undefined_syms_auto_path: undefined_syms_auto.txt
-  # symbol_addrs_path: symbol_addrs.txt
-  # asm_path: asm
-  # src_path: src
-  # build_path: build
-  # extensions_path: tools/splat_ext
-  # mips_abi_float_regs: o32
+
+  o_as_suffix: True
+  use_legacy_include_asm: False
+  mips_abi_float_regs: o32
+
+  asm_function_macro: glabel
+  asm_jtbl_label_macro: jlabel
+  asm_data_macro: dlabel
+
   # section_order: [".text", ".data", ".rodata", ".bss"]
   # auto_all_sections: [".data", ".rodata", ".bss"]
+
+  symbol_addrs_path:
+    - symbol_addrs.txt
+  undefined_funcs_auto_path:
+    - undefined_funcs_auto.txt
+  undefined_syms_auto_path:
+    - undefined_syms_auto.txt
+  reloc_addrs_path:
+    - reloc_addrs.txt
+
+  extensions_path: tools/splat_ext
+
+  # string_encoding: ASCII
+  # data_string_encoding: ASCII
+  rodata_string_guesser_level: 2
+  data_string_guesser_level: 2
   # libultra_symbols: True
   # hardware_regs: True
+  # gfx_ucode: # one of [f3d, f3db, f3dex, f3dexb, f3dex2]
 """
 
     first_section_end = find_code_length.run(rom_bytes, 0x1000, rom.entry_point)
@@ -212,6 +236,7 @@ options:
   asm_path: asm
   src_path: src
   build_path: build
+  # create_asm_dependencies: True
 
   ld_script_path: {basename}.ld
 
@@ -228,10 +253,14 @@ options:
   section_order: [".rodata", ".text", ".data", ".bss"]
   # auto_all_sections: [".data", ".rodata", ".bss"]
 
-  symbol_addrs_path: symbol_addrs.txt
-  undefined_funcs_auto_path: undefined_funcs_auto.txt
-  undefined_syms_auto_path: undefined_syms_auto.txt
-  reloc_addrs_path: reloc_addrs.txt
+  symbol_addrs_path:
+    - symbol_addrs.txt
+  undefined_funcs_auto_path:
+    - undefined_funcs_auto.txt
+  undefined_syms_auto_path:
+    - undefined_syms_auto.txt
+  reloc_addrs_path:
+    - reloc_addrs.txt
 
   extensions_path: tools/splat_ext
 

--- a/create_config.py
+++ b/create_config.py
@@ -196,9 +196,6 @@ segments:
 
 
 def create_psx_config(exe_path: Path, exe_bytes: bytes):
-    # rom_bytes = rominfo.read_rom(rom_path)
-
-    # rom = rominfo.get_info(rom_path, file_bytes)
     exe = psxexeinfo.PsxExe.get_info(exe_path, exe_bytes)
     basename = exe_path.name.replace(" ", "").lower()
 

--- a/util/psx/psxexeinfo.py
+++ b/util/psx/psxexeinfo.py
@@ -1,0 +1,70 @@
+#! /usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+
+import hashlib
+import itertools
+import struct
+
+import sys
+import zlib
+import dataclasses
+
+from pathlib import Path
+from typing import Optional
+
+import rabbitizer
+import spimdisasm
+
+@dataclasses.dataclass
+class PsxExe:
+    # Based on https://psx-spx.consoledev.net/cdromdrive/#filenameexe-general-purpose-executable
+    initial_pc: int # offset: 0x10
+    initial_gp: int # offset: 0x14
+    text_vram: int # offset: 0x18
+    text_size: int # offset: 0x1C
+    data_vram: int # offset: 0x20
+    data_size: int # offset: 0x24
+    bss_vram: int # offset: 0x28
+    bss_size: int # offset: 0x2C
+    initial_sp_base: int # offset: 0x30
+    initial_sp_offset: int # offset: 0x34
+
+    size: int
+    sha1: str
+
+    @property
+    def text_offset(self) -> int:
+        return self.initial_pc - self.text_vram + 0x800
+
+    @staticmethod
+    def get_info(exe_path: Path, exe_bytes: bytes) -> PsxExe:
+        initial_pc = struct.unpack("<I", exe_bytes[0x10:0x10+4])[0]
+        initial_gp = struct.unpack("<I", exe_bytes[0x14:0x14+4])[0]
+        text_vram = struct.unpack("<I", exe_bytes[0x18:0x18+4])[0]
+        text_size = struct.unpack("<I", exe_bytes[0x1C:0x1C+4])[0]
+        data_vram = struct.unpack("<I", exe_bytes[0x20:0x20+4])[0]
+        data_size = struct.unpack("<I", exe_bytes[0x24:0x24+4])[0]
+        bss_vram = struct.unpack("<I", exe_bytes[0x28:0x28+4])[0]
+        bss_size = struct.unpack("<I", exe_bytes[0x2C:0x2C+4])[0]
+        initial_sp_base = struct.unpack("<I", exe_bytes[0x30:0x30+4])[0]
+        initial_sp_offset = struct.unpack("<I", exe_bytes[0x34:0x34+4])[0]
+
+        sha1 = hashlib.sha1(exe_bytes).hexdigest()
+
+        return PsxExe(
+            initial_pc,
+            initial_gp,
+            text_vram,
+            text_size,
+            data_vram,
+            data_size,
+            bss_vram,
+            bss_size,
+            initial_sp_base,
+            initial_sp_offset,
+            len(exe_bytes),
+            sha1,
+        )

--- a/util/psx/psxexeinfo.py
+++ b/util/psx/psxexeinfo.py
@@ -68,3 +68,50 @@ class PsxExe:
             len(exe_bytes),
             sha1,
         )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Gives information on PSX EXEs")
+    parser.add_argument("exe", help="path to an PSX EXE")
+
+    args = parser.parse_args()
+
+    exe_path = Path(args.exe)
+    exe_bytes = exe_path.read_bytes()
+    exe = PsxExe.get_info(exe_path, exe_bytes)
+
+    print(f"Initial PC: 0x{exe.initial_pc:08X}")
+
+    print(f"Initial GP: ", end="")
+    if exe.initial_gp != 0:
+        print(f"0x{exe.initial_gp:08X}")
+    else:
+        print(f"No")
+
+    print()
+    print(f"Destination VRAM: 0x{exe.destination_vram:08X}")
+    print(f"File size (without header): 0x{exe.file_size:X}")
+    print(f"Text binary offset: 0x{exe.text_offset:08X}")
+
+    if exe.data_vram != 0 and exe.data_size != 0:
+        print()
+        print(f"Data VRAM: 0x{exe.data_vram:08X}")
+        print(f"Data size: 0x{exe.data_size:08X}")
+        print(f"Data binary offset: 0x{exe.data_offset:08X}")
+
+    if exe.bss_vram != 0 and exe.bss_size != 0:
+        print()
+        print(f"bss VRAM: 0x{exe.bss_vram:08X}")
+        print(f"bss size: 0x{exe.bss_size:08X}")
+
+    print()
+    print(f"Initial SP base: 0x{exe.initial_sp_base:08X}")
+    print(f"Initial SP offset: 0x{exe.initial_sp_offset:08X}")
+
+    print()
+    print(f"File size: 0x{exe.size:X}")
+    print(f"sha1: {exe.sha1}")
+
+
+if __name__ == "__main__":
+    main()

--- a/util/psx/psxexeinfo.py
+++ b/util/psx/psxexeinfo.py
@@ -5,26 +5,19 @@ from __future__ import annotations
 import argparse
 
 import hashlib
-import itertools
 import struct
 
-import sys
-import zlib
 import dataclasses
 
 from pathlib import Path
-from typing import Optional
-
-import rabbitizer
-import spimdisasm
 
 @dataclasses.dataclass
 class PsxExe:
     # Based on https://psx-spx.consoledev.net/cdromdrive/#filenameexe-general-purpose-executable
     initial_pc: int # offset: 0x10
     initial_gp: int # offset: 0x14
-    text_vram: int # offset: 0x18
-    text_size: int # offset: 0x1C
+    destination_vram: int # offset: 0x18
+    file_size: int # offset: 0x1C
     data_vram: int # offset: 0x20
     data_size: int # offset: 0x24
     bss_vram: int # offset: 0x28
@@ -37,14 +30,21 @@ class PsxExe:
 
     @property
     def text_offset(self) -> int:
-        return self.initial_pc - self.text_vram + 0x800
+        return self.initial_pc - self.destination_vram + 0x800
+
+    @property
+    def data_offset(self) -> int:
+        if self.data_vram == 0 or self.data_size == 0:
+            return 0
+        return self.data_vram - self.destination_vram + 0x800
+
 
     @staticmethod
     def get_info(exe_path: Path, exe_bytes: bytes) -> PsxExe:
         initial_pc = struct.unpack("<I", exe_bytes[0x10:0x10+4])[0]
         initial_gp = struct.unpack("<I", exe_bytes[0x14:0x14+4])[0]
-        text_vram = struct.unpack("<I", exe_bytes[0x18:0x18+4])[0]
-        text_size = struct.unpack("<I", exe_bytes[0x1C:0x1C+4])[0]
+        destination_vram = struct.unpack("<I", exe_bytes[0x18:0x18+4])[0]
+        file_size = struct.unpack("<I", exe_bytes[0x1C:0x1C+4])[0]
         data_vram = struct.unpack("<I", exe_bytes[0x20:0x20+4])[0]
         data_size = struct.unpack("<I", exe_bytes[0x24:0x24+4])[0]
         bss_vram = struct.unpack("<I", exe_bytes[0x28:0x28+4])[0]
@@ -57,8 +57,8 @@ class PsxExe:
         return PsxExe(
             initial_pc,
             initial_gp,
-            text_vram,
-            text_size,
+            destination_vram,
+            file_size,
             data_vram,
             data_size,
             bss_vram,

--- a/util/psx/psxexeinfo.py
+++ b/util/psx/psxexeinfo.py
@@ -11,19 +11,20 @@ import dataclasses
 
 from pathlib import Path
 
+
 @dataclasses.dataclass
 class PsxExe:
     # Based on https://psx-spx.consoledev.net/cdromdrive/#filenameexe-general-purpose-executable
-    initial_pc: int # offset: 0x10
-    initial_gp: int # offset: 0x14
-    destination_vram: int # offset: 0x18
-    file_size: int # offset: 0x1C
-    data_vram: int # offset: 0x20
-    data_size: int # offset: 0x24
-    bss_vram: int # offset: 0x28
-    bss_size: int # offset: 0x2C
-    initial_sp_base: int # offset: 0x30
-    initial_sp_offset: int # offset: 0x34
+    initial_pc: int  # offset: 0x10
+    initial_gp: int  # offset: 0x14
+    destination_vram: int  # offset: 0x18
+    file_size: int  # offset: 0x1C
+    data_vram: int  # offset: 0x20
+    data_size: int  # offset: 0x24
+    bss_vram: int  # offset: 0x28
+    bss_size: int  # offset: 0x2C
+    initial_sp_base: int  # offset: 0x30
+    initial_sp_offset: int  # offset: 0x34
 
     size: int
     sha1: str
@@ -38,19 +39,18 @@ class PsxExe:
             return 0
         return self.data_vram - self.destination_vram + 0x800
 
-
     @staticmethod
     def get_info(exe_path: Path, exe_bytes: bytes) -> PsxExe:
-        initial_pc = struct.unpack("<I", exe_bytes[0x10:0x10+4])[0]
-        initial_gp = struct.unpack("<I", exe_bytes[0x14:0x14+4])[0]
-        destination_vram = struct.unpack("<I", exe_bytes[0x18:0x18+4])[0]
-        file_size = struct.unpack("<I", exe_bytes[0x1C:0x1C+4])[0]
-        data_vram = struct.unpack("<I", exe_bytes[0x20:0x20+4])[0]
-        data_size = struct.unpack("<I", exe_bytes[0x24:0x24+4])[0]
-        bss_vram = struct.unpack("<I", exe_bytes[0x28:0x28+4])[0]
-        bss_size = struct.unpack("<I", exe_bytes[0x2C:0x2C+4])[0]
-        initial_sp_base = struct.unpack("<I", exe_bytes[0x30:0x30+4])[0]
-        initial_sp_offset = struct.unpack("<I", exe_bytes[0x34:0x34+4])[0]
+        initial_pc = struct.unpack("<I", exe_bytes[0x10 : 0x10 + 4])[0]
+        initial_gp = struct.unpack("<I", exe_bytes[0x14 : 0x14 + 4])[0]
+        destination_vram = struct.unpack("<I", exe_bytes[0x18 : 0x18 + 4])[0]
+        file_size = struct.unpack("<I", exe_bytes[0x1C : 0x1C + 4])[0]
+        data_vram = struct.unpack("<I", exe_bytes[0x20 : 0x20 + 4])[0]
+        data_size = struct.unpack("<I", exe_bytes[0x24 : 0x24 + 4])[0]
+        bss_vram = struct.unpack("<I", exe_bytes[0x28 : 0x28 + 4])[0]
+        bss_size = struct.unpack("<I", exe_bytes[0x2C : 0x2C + 4])[0]
+        initial_sp_base = struct.unpack("<I", exe_bytes[0x30 : 0x30 + 4])[0]
+        initial_sp_offset = struct.unpack("<I", exe_bytes[0x34 : 0x34 + 4])[0]
 
         sha1 = hashlib.sha1(exe_bytes).hexdigest()
 


### PR DESCRIPTION
`create_config.py` can now create a yaml for PSX-EXE files.
I'm not sure how useful this could be since most files on a psx disk are not exe, but there should always be an exe there, so people could use it as a starting point (?)

Since I'm touching this script I decided to also update the default options for n64 yamls. A few notable changes would be using dlabel, jlabel and o32 register names by default.