### PR TITLE
incbin segments

### DIFF
--- a/segtypes/common/bin.py
+++ b/segtypes/common/bin.py
@@ -7,6 +7,10 @@ from segtypes.common.segment import CommonSegment
 
 
 class CommonSegBin(CommonSegment):
+    @staticmethod
+    def is_data() -> bool:
+        return True
+
     def out_path(self) -> Optional[Path]:
         return options.opts.asset_path / self.dir / f"{self.name}.bin"
 

--- a/segtypes/common/code.py
+++ b/segtypes/common/code.py
@@ -314,6 +314,16 @@ class CommonSegCode(CommonSegGroup):
                         segment.rodata_sibling = segment.sibling
                         segment.sibling.sibling = segment
 
+                if self.section_order.index(".text") < self.section_order.index(
+                    ".data"
+                ):
+                    if segment.is_data():
+                        segment.sibling.data_sibling = segment
+                else:
+                    if segment.is_text() and segment.sibling.is_data():
+                        segment.data_sibling = segment.sibling
+                        segment.sibling.sibling = segment
+
             segment.parent = self
             if segment.special_vram_segment:
                 self.special_vram_segment = True

--- a/segtypes/common/data.py
+++ b/segtypes/common/data.py
@@ -10,6 +10,10 @@ from disassembler_section import make_data_section
 
 
 class CommonSegData(CommonSegCodeSubsegment, CommonSegGroup):
+    @staticmethod
+    def is_data() -> bool:
+        return True
+
     def asm_out_path(self) -> Path:
         typ = self.type
         if typ.startswith("."):

--- a/segtypes/common/databin.py
+++ b/segtypes/common/databin.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+from typing import Optional
+
+from util import log, options
+
+from segtypes.common.textbin import CommonSegTextbin
+
+
+class CommonSegDatabin(CommonSegTextbin):
+    @staticmethod
+    def is_text() -> bool:
+        return False
+
+    @staticmethod
+    def is_data() -> bool:
+        return True
+
+    def get_linker_section(self) -> str:
+        return ".data"
+
+    def get_section_flags(self) -> Optional[str]:
+        return "wa"
+
+    def split(self, rom_bytes):
+        if self.rom_end is None:
+            log.error(
+                f"segment {self.name} needs to know where it ends; add a position marker [0xDEADBEEF] after it"
+            )
+
+        self.write_bin(rom_bytes)
+
+        if self.sibling is None:
+            # textbin will write the incbin instead
+
+            s_path = self.out_path()
+            assert s_path is not None
+            s_path.parent.mkdir(parents=True, exist_ok=True)
+
+            with s_path.open("w") as f:
+                f.write('.include "macro.inc"\n\n')
+                preamble = options.opts.generated_s_preamble
+                if preamble:
+                    f.write(preamble + "\n")
+
+                self.write_asm_contents(rom_bytes, f)

--- a/segtypes/common/header.py
+++ b/segtypes/common/header.py
@@ -6,6 +6,10 @@ from segtypes.common.segment import CommonSegment
 
 
 class CommonSegHeader(CommonSegment):
+    @staticmethod
+    def is_data() -> bool:
+        return True
+
     def should_split(self):
         return self.extract and options.opts.is_mode_active("code")
 

--- a/segtypes/common/rodatabin.py
+++ b/segtypes/common/rodatabin.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+from typing import Optional
+
+from util import log, options
+
+from segtypes.common.textbin import CommonSegTextbin
+
+
+class CommonSegRodatabin(CommonSegTextbin):
+    @staticmethod
+    def is_text() -> bool:
+        return False
+
+    @staticmethod
+    def is_rodata() -> bool:
+        return True
+
+    def get_linker_section(self) -> str:
+        return ".rodata"
+
+    def get_section_flags(self) -> Optional[str]:
+        return "a"
+
+    def split(self, rom_bytes):
+        if self.rom_end is None:
+            log.error(
+                f"segment {self.name} needs to know where it ends; add a position marker [0xDEADBEEF] after it"
+            )
+
+        self.write_bin(rom_bytes)
+
+        if self.sibling is None:
+            # textbin will write the incbin instead
+
+            s_path = self.out_path()
+            assert s_path is not None
+            s_path.parent.mkdir(parents=True, exist_ok=True)
+
+            with s_path.open("w") as f:
+                f.write('.include "macro.inc"\n\n')
+                preamble = options.opts.generated_s_preamble
+                if preamble:
+                    f.write(preamble + "\n")
+
+                self.write_asm_contents(rom_bytes, f)

--- a/segtypes/common/textbin.py
+++ b/segtypes/common/textbin.py
@@ -27,7 +27,6 @@ class CommonSegTextbin(CommonSegment):
 
         return options.opts.asset_path / self.dir / f"{self.name}.{typ}.bin"
 
-
     def write_bin(self, rom_bytes):
         binpath = self.bin_path()
         binpath.parent.mkdir(parents=True, exist_ok=True)
@@ -38,7 +37,6 @@ class CommonSegTextbin(CommonSegment):
         binpath.write_bytes(rom_bytes[self.rom_start : self.rom_end])
 
         self.log(f"Wrote {self.name} to {binpath}")
-
 
     def write_asm_contents(self, rom_bytes, f: TextIO):
         binpath = self.bin_path()
@@ -64,9 +62,11 @@ class CommonSegTextbin(CommonSegment):
         f.write(f'.incbin "{binpath}"\n')
 
         if sym is not None and sym.given_name_end is not None:
-            if sym.given_size is None or sym.given_size == self.rom_end - self.rom_start:
+            if (
+                sym.given_size is None
+                or sym.given_size == self.rom_end - self.rom_start
+            ):
                 f.write(f"{options.opts.asm_function_macro} {sym.given_name_end}\n")
-
 
     def split(self, rom_bytes):
         if self.rom_end is None:
@@ -108,4 +108,3 @@ class CommonSegTextbin(CommonSegment):
         return (
             self.extract and options.opts.is_mode_active("code") and self.should_scan()
         )  # only split if the segment was scanned first
-

--- a/segtypes/common/textbin.py
+++ b/segtypes/common/textbin.py
@@ -88,6 +88,10 @@ class CommonSegTextbin(CommonSegment):
             self.write_asm_contents(rom_bytes, f)
 
             # We check against CommonSegTextbin instead of the specific type because the other incbins inherit from this class
+            if isinstance(self.data_sibling, CommonSegTextbin):
+                f.write("\n")
+                self.data_sibling.write_asm_contents(rom_bytes, f)
+
             if isinstance(self.rodata_sibling, CommonSegTextbin):
                 f.write("\n")
                 self.rodata_sibling.write_asm_contents(rom_bytes, f)

--- a/segtypes/common/textbin.py
+++ b/segtypes/common/textbin.py
@@ -64,7 +64,8 @@ class CommonSegTextbin(CommonSegment):
         f.write(f'.incbin "{binpath}"\n')
 
         if sym is not None and sym.given_name_end is not None:
-            f.write(f"{options.opts.asm_function_macro} {sym.given_name_end}\n")
+            if sym.given_size is None or sym.given_size == self.rom_end - self.rom_start:
+                f.write(f"{options.opts.asm_function_macro} {sym.given_name_end}\n")
 
 
     def split(self, rom_bytes):

--- a/segtypes/common/textbin.py
+++ b/segtypes/common/textbin.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+from typing import Optional
+
+from util import log, options
+
+from segtypes.common.segment import CommonSegment
+
+
+class CommonSegTextbin(CommonSegment):
+    @staticmethod
+    def is_text() -> bool:
+        return True
+
+    def get_linker_section(self) -> str:
+        return ".text"
+
+    def get_section_flags(self) -> Optional[str]:
+        return "ax"
+
+    def out_path(self) -> Optional[Path]:
+        return options.opts.data_path / self.dir / f"{self.name}.s"
+
+    def bin_path(self) -> Path:
+        typ = self.type
+        if typ.startswith("."):
+            typ = typ[1:]
+
+        return options.opts.asset_path / self.dir / f"{self.name}.{typ}.bin"
+
+    def split(self, rom_bytes):
+        s_path = self.out_path()
+        assert s_path is not None
+        s_path.parent.mkdir(parents=True, exist_ok=True)
+        binpath = self.bin_path()
+        binpath.parent.mkdir(parents=True, exist_ok=True)
+
+        if self.rom_end is None:
+            log.error(
+                f"segment {self.name} needs to know where it ends; add a position marker [0xDEADBEEF] after it"
+            )
+
+        assert isinstance(self.rom_start, int)
+        assert isinstance(self.rom_end, int)
+
+        binpath.write_bytes(rom_bytes[self.rom_start : self.rom_end])
+
+        self.log(f"Wrote {self.name} to {binpath}")
+
+        with s_path.open("w") as f:
+            f.write(f".section {self.get_linker_section()}")
+            section_flags = self.get_section_flags()
+            if section_flags:
+                f.write(f', "{section_flags}"')
+            f.write("\n\n")
+
+            f.write(f'.incbin "{binpath}"\n')
+
+    def should_scan(self) -> bool:
+        return (
+            options.opts.is_mode_active("code")
+            and self.rom_start is not None
+            and self.rom_end is not None
+        )
+
+    def should_split(self) -> bool:
+        return (
+            self.extract and options.opts.is_mode_active("code") and self.should_scan()
+        )  # only split if the segment was scanned first
+

--- a/segtypes/common/textbin.py
+++ b/segtypes/common/textbin.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional
+from typing import Optional, TextIO
 
 from util import log, options
 
@@ -27,17 +27,10 @@ class CommonSegTextbin(CommonSegment):
 
         return options.opts.asset_path / self.dir / f"{self.name}.{typ}.bin"
 
-    def split(self, rom_bytes):
-        s_path = self.out_path()
-        assert s_path is not None
-        s_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def write_bin(self, rom_bytes):
         binpath = self.bin_path()
         binpath.parent.mkdir(parents=True, exist_ok=True)
-
-        if self.rom_end is None:
-            log.error(
-                f"segment {self.name} needs to know where it ends; add a position marker [0xDEADBEEF] after it"
-            )
 
         assert isinstance(self.rom_start, int)
         assert isinstance(self.rom_end, int)
@@ -46,31 +39,58 @@ class CommonSegTextbin(CommonSegment):
 
         self.log(f"Wrote {self.name} to {binpath}")
 
+
+    def write_asm_contents(self, rom_bytes, f: TextIO):
+        binpath = self.bin_path()
+
+        assert isinstance(self.rom_start, int)
+        assert isinstance(self.rom_end, int)
+
+        f.write(f".section {self.get_linker_section()}")
+        section_flags = self.get_section_flags()
+        if section_flags:
+            f.write(f', "{section_flags}"')
+        f.write("\n\n")
+
+        # Check if there's a symbol at this address
+        sym = None
+        vram = self.rom_to_ram(self.rom_start)
+        if vram is not None:
+            sym = self.get_symbol(vram, in_segment=True)
+
+        if sym is not None:
+            f.write(f"{options.opts.asm_function_macro} {sym.name}\n")
+
+        f.write(f'.incbin "{binpath}"\n')
+
+        if sym is not None and sym.given_name_end is not None:
+            f.write(f"{options.opts.asm_function_macro} {sym.given_name_end}\n")
+
+
+    def split(self, rom_bytes):
+        if self.rom_end is None:
+            log.error(
+                f"segment {self.name} needs to know where it ends; add a position marker [0xDEADBEEF] after it"
+            )
+
+        self.write_bin(rom_bytes)
+
+        s_path = self.out_path()
+        assert s_path is not None
+        s_path.parent.mkdir(parents=True, exist_ok=True)
+
         with s_path.open("w") as f:
             f.write('.include "macro.inc"\n\n')
             preamble = options.opts.generated_s_preamble
             if preamble:
                 f.write(preamble + "\n")
 
-            f.write(f".section {self.get_linker_section()}")
-            section_flags = self.get_section_flags()
-            if section_flags:
-                f.write(f', "{section_flags}"')
-            f.write("\n\n")
+            self.write_asm_contents(rom_bytes, f)
 
-            # Check if there's a symbol at this address
-            sym = None
-            vram = self.rom_to_ram(self.rom_start)
-            if vram is not None:
-                sym = self.get_symbol(vram, in_segment=True)
-
-            if sym is not None:
-                f.write(f"{options.opts.asm_function_macro} {sym.name}\n")
-
-            f.write(f'.incbin "{binpath}"\n')
-
-            if sym is not None and sym.given_name_end is not None:
-                f.write(f"{options.opts.asm_function_macro} {sym.given_name_end}\n")
+            # We check against CommonSegTextbin instead of the specific type because the other incbins inherit from this class
+            if isinstance(self.rodata_sibling, CommonSegTextbin):
+                f.write("\n")
+                self.rodata_sibling.write_asm_contents(rom_bytes, f)
 
     def should_scan(self) -> bool:
         return (

--- a/segtypes/segment.py
+++ b/segtypes/segment.py
@@ -216,6 +216,7 @@ class Segment:
 
         self.parent: Optional[Segment] = None
         self.sibling: Optional[Segment] = None
+        self.data_sibling: Optional[Segment] = None
         self.rodata_sibling: Optional[Segment] = None
         self.file_path: Optional[Path] = None
 
@@ -292,6 +293,11 @@ class Segment:
     # For executable segments (.text); like c, asm or hasm
     @staticmethod
     def is_text() -> bool:
+        return False
+
+    # For read-write segments (.data); like data
+    @staticmethod
+    def is_data() -> bool:
         return False
 
     # For readonly segments (.rodata); like rodata or rdata


### PR DESCRIPTION
Introduces 3 new segments types, `textbin`, `databin` and `rodatabin` which allows to specify bins in text, data or rodata sections instead of the default.
This generates an asm file that `.incbin`s the outputted bin, specifying the section type, a symbol if the vram address of the file matches a known symbol.
If there is a `databin` and/or `rodatabin` section with the same name as the `textbin` then the generated asm file will also `.incbin` the other segment's bins