### PR TITLE
Label for alt symbols and option to automatically fill iQue libultra syms

### DIFF
--- a/disassembler/spimdisasm_disassembler.py
+++ b/disassembler/spimdisasm_disassembler.py
@@ -80,6 +80,7 @@ class SpimdisasmDisassembler(disassembler.Disassembler):
         spimdisasm.common.GlobalConfig.GP_VALUE = opts.gp
 
         spimdisasm.common.GlobalConfig.ASM_TEXT_LABEL = opts.asm_function_macro
+        spimdisasm.common.GlobalConfig.ASM_TEXT_ALT_LABEL = opts.asm_function_alt_macro
         spimdisasm.common.GlobalConfig.ASM_JTBL_LABEL = opts.asm_jtbl_label_macro
         spimdisasm.common.GlobalConfig.ASM_DATA_LABEL = opts.asm_data_macro
         spimdisasm.common.GlobalConfig.ASM_TEXT_END_LABEL = opts.asm_end_label

--- a/disassembler/spimdisasm_disassembler.py
+++ b/disassembler/spimdisasm_disassembler.py
@@ -8,7 +8,7 @@ from typing import Set
 
 class SpimdisasmDisassembler(disassembler.Disassembler):
     # This value should be kept in sync with the version listed on requirements.txt
-    SPIMDISASM_MIN = (1, 16, 0)
+    SPIMDISASM_MIN = (1, 17, 0)
 
     def configure(self, opts: SplatOpts):
         # Configure spimdisasm

--- a/platforms/n64.py
+++ b/platforms/n64.py
@@ -1,4 +1,4 @@
-from util import compiler, log, options, palettes, symbols
+from util import options, symbols
 
 
 def init(target_bytes: bytes):

--- a/platforms/n64.py
+++ b/platforms/n64.py
@@ -6,5 +6,7 @@ def init(target_bytes: bytes):
 
     if options.opts.libultra_symbols:
         symbols.spim_context.globalSegment.fillLibultraSymbols()
+    if options.opts.ique_symbols:
+        symbols.spim_context.globalSegment.fillIQueSymbols
     if options.opts.hardware_regs:
         symbols.spim_context.globalSegment.fillHardwareRegs(True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ tqdm
 intervaltree
 colorama
 # This value should be keep in sync with the version listed on disassembler/spimdisasm_disassembler.py
-spimdisasm>=1.16.0
+spimdisasm>=1.17.0
 rabbitizer>=1.7.0
 pygfxd
 n64img>=0.1.4

--- a/util/compiler.py
+++ b/util/compiler.py
@@ -6,6 +6,7 @@ from typing import Optional
 class Compiler:
     name: str
     asm_function_macro: str = "glabel"
+    asm_function_alt_macro: str = "glabel"
     asm_jtbl_label_macro: str = "glabel"
     asm_data_macro: str = "glabel"
     asm_end_label: str = ""

--- a/util/options.py
+++ b/util/options.py
@@ -194,6 +194,8 @@ class SplatOpts:
     gfx_ucode: str
     # Use named libultra symbols by default. Those will need to be added to a linker script manually by the user
     libultra_symbols: bool
+    # Use named libultra symbols by default. Those will need to be added to a linker script manually by the user
+    ique_symbols: bool
     # Use named hardware register symbols by default. Those will need to be added to a linker script manually by the user
     hardware_regs: bool
 
@@ -444,6 +446,7 @@ def _parse_yaml(
             "f3dex2",
         ),
         libultra_symbols=p.parse_opt("libultra_symbols", bool, False),
+        ique_symbols=p.parse_opt("ique_symbols", bool, False),
         hardware_regs=p.parse_opt("hardware_regs", bool, False),
         use_legacy_include_asm=p.parse_opt("use_legacy_include_asm", bool, True),
         filesystem_path=p.parse_optional_path(base_path, "filesystem_path"),

--- a/util/options.py
+++ b/util/options.py
@@ -140,6 +140,8 @@ class SplatOpts:
     asm_inc_header: str
     # Determines the macro used to declare functions in asm files
     asm_function_macro: str
+    # Determines the macro used to declare symbols in the middle of functions in asm files (which may be alternative entries)
+    asm_function_alt_macro: str
     # Determines the macro used to declare jumptable labels in asm files
     asm_jtbl_label_macro: str
     # Determines the macro used to declare data symbols in asm files
@@ -403,6 +405,9 @@ def _parse_yaml(
         asm_inc_header=p.parse_opt("asm_inc_header", str, comp.asm_inc_header),
         asm_function_macro=p.parse_opt(
             "asm_function_macro", str, comp.asm_function_macro
+        ),
+        asm_function_alt_macro=p.parse_opt(
+            "asm_function_alt_macro", str, comp.asm_function_alt_macro
         ),
         asm_jtbl_label_macro=p.parse_opt(
             "asm_jtbl_label_macro", str, comp.asm_jtbl_label_macro


### PR DESCRIPTION
Latest spimdisasm allows to set a different label for symbols in the middle of functions, allowing `glabel` to be used as a proper function entry point.
spimdisasm also has the option to automatically set and name iQue libultra symbols. In earlier versions those symbols were used automatically when using normal libultra symbols, but this new option gives finer control so normal games don't have to worry about this