### PR TITLE
`ld_sections_allowlist` and `ld_sections_denylist` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ### 0.17.1
 
-* New yaml options: `ld_sections_whitelist` and `ld_sections_blacklist`
-  * `ld_sections_whitelist`: A list of sections to preserve during link time. It can be useful to preserve debugging sections.
-  * `ld_sections_blacklist`: A list of sections to discard during link time. It can be useful to avoid using the wildcard discard. Note that this option does not turn off `ld_discard_section`.
+* New yaml options: `ld_sections_allowlist` and `ld_sections_denylist`
+  * `ld_sections_allowlist`: A list of sections to preserve during link time. It can be useful to preserve debugging sections.
+  * `ld_sections_denylist`: A list of sections to discard during link time. It can be useful to avoid using the wildcard discard. Note that this option does not turn off `ld_discard_section`.
 
 ### 0.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # splat Release Notes
 
+### 0.17.1
+
+* New yaml options: `ld_sections_whitelist` and `ld_sections_blacklist`
+  * `ld_sections_whitelist`: A list of sections to preserve during link time. It can be useful to preserve debugging sections.
+  * `ld_sections_blacklist`: A list of sections to discard during link time. It can be useful to avoid using the wildcard discard. Note that this option does not turn off `ld_discard_section`.
+
 ### 0.17.0
 
 * BREAKING: Linker script generation now imposes the specified `section_order`, which may not completely reflect the yaml order.

--- a/segtypes/linker_entry.py
+++ b/segtypes/linker_entry.py
@@ -411,6 +411,18 @@ class LinkerWriter:
             self._end_partial_segment(section_name)
 
     def save_linker_script(self, output_path: Path):
+        if len(self.sections_whitelist) > 0:
+            address = " 0"
+            if self.is_partial:
+                address = ""
+            for sect in self.sections_whitelist:
+                self._writeln(f"{sect}{address} :")
+                self._begin_block()
+                self._writeln(f"*({sect});")
+                self._end_block()
+
+            self._writeln("")
+
         if self.linker_discard_section or len(self.sections_blacklist) > 0:
             self._writeln("/DISCARD/ :")
             self._begin_block()

--- a/segtypes/linker_entry.py
+++ b/segtypes/linker_entry.py
@@ -159,8 +159,8 @@ class LinkerEntry:
 class LinkerWriter:
     def __init__(self, is_partial: bool = False):
         self.linker_discard_section: bool = options.opts.ld_discard_section
-        self.sections_whitelist: List[str] = options.opts.ld_sections_whitelist
-        self.sections_blacklist: List[str] = options.opts.ld_sections_blacklist
+        self.sections_allowlist: List[str] = options.opts.ld_sections_allowlist
+        self.sections_denylist: List[str] = options.opts.ld_sections_denylist
         # Used to store all the linker entries - build tools may want this information
         self.entries: List[LinkerEntry] = []
         self.dependencies_entries: List[LinkerEntry] = []
@@ -411,11 +411,11 @@ class LinkerWriter:
             self._end_partial_segment(section_name)
 
     def save_linker_script(self, output_path: Path):
-        if len(self.sections_whitelist) > 0:
+        if len(self.sections_allowlist) > 0:
             address = " 0"
             if self.is_partial:
                 address = ""
-            for sect in self.sections_whitelist:
+            for sect in self.sections_allowlist:
                 self._writeln(f"{sect}{address} :")
                 self._begin_block()
                 self._writeln(f"*({sect});")
@@ -423,10 +423,10 @@ class LinkerWriter:
 
             self._writeln("")
 
-        if self.linker_discard_section or len(self.sections_blacklist) > 0:
+        if self.linker_discard_section or len(self.sections_denylist) > 0:
             self._writeln("/DISCARD/ :")
             self._begin_block()
-            for sect in self.sections_blacklist:
+            for sect in self.sections_denylist:
                 self._writeln(f"*({sect});")
             if self.linker_discard_section:
                 self._writeln("*(*);")

--- a/split.py
+++ b/split.py
@@ -25,7 +25,7 @@ from segtypes.linker_entry import (
 from segtypes.segment import Segment
 from util import log, options, palettes, symbols, relocs
 
-VERSION = "0.17.0"
+VERSION = "0.17.1"
 
 parser = argparse.ArgumentParser(
     description="Split a rom given a rom, a config, and output directory"

--- a/util/options.py
+++ b/util/options.py
@@ -97,9 +97,9 @@ class SplatOpts:
     ld_symbol_header_path: Optional[Path]
     # Determines whether to add a discard section with a wildcard to the linker script
     ld_discard_section: bool
-    # 
+    # A list of sections to preserve during link time. It can be useful to preserve debugging sections
     ld_sections_whitelist: List[str]
-    # 
+    # A list of sections to discard during link time. It can be useful to avoid using the wildcard discard. Note that this option does not turn off `ld_discard_section`
     ld_sections_blacklist: List[str]
     # Determines the list of section labels that are to be added to the linker script
     ld_section_labels: List[str]

--- a/util/options.py
+++ b/util/options.py
@@ -95,8 +95,12 @@ class SplatOpts:
     # Determines the desired path to the linker symbol header,
     # which exposes externed definitions for all segment ram/rom start/end locations
     ld_symbol_header_path: Optional[Path]
-    # Determines whether to add a discard section to the linker script
+    # Determines whether to add a discard section with a wildcard to the linker script
     ld_discard_section: bool
+    # 
+    ld_sections_whitelist: List[str]
+    # 
+    ld_sections_blacklist: List[str]
     # Determines the list of section labels that are to be added to the linker script
     ld_section_labels: List[str]
     # Determines whether to add wildcards for section linking in the linker script (.rodata* for example)
@@ -386,6 +390,8 @@ def _parse_yaml(
         ld_script_path=p.parse_path(base_path, "ld_script_path", f"{basename}.ld"),
         ld_symbol_header_path=p.parse_optional_path(base_path, "ld_symbol_header_path"),
         ld_discard_section=p.parse_opt("ld_discard_section", bool, True),
+        ld_sections_whitelist=p.parse_opt("ld_sections_whitelist", list, []),
+        ld_sections_blacklist=p.parse_opt("ld_sections_blacklist", list, []),
         ld_section_labels=p.parse_opt(
             "ld_section_labels",
             list,

--- a/util/options.py
+++ b/util/options.py
@@ -98,9 +98,9 @@ class SplatOpts:
     # Determines whether to add a discard section with a wildcard to the linker script
     ld_discard_section: bool
     # A list of sections to preserve during link time. It can be useful to preserve debugging sections
-    ld_sections_whitelist: List[str]
+    ld_sections_allowlist: List[str]
     # A list of sections to discard during link time. It can be useful to avoid using the wildcard discard. Note that this option does not turn off `ld_discard_section`
-    ld_sections_blacklist: List[str]
+    ld_sections_denylist: List[str]
     # Determines the list of section labels that are to be added to the linker script
     ld_section_labels: List[str]
     # Determines whether to add wildcards for section linking in the linker script (.rodata* for example)
@@ -390,8 +390,8 @@ def _parse_yaml(
         ld_script_path=p.parse_path(base_path, "ld_script_path", f"{basename}.ld"),
         ld_symbol_header_path=p.parse_optional_path(base_path, "ld_symbol_header_path"),
         ld_discard_section=p.parse_opt("ld_discard_section", bool, True),
-        ld_sections_whitelist=p.parse_opt("ld_sections_whitelist", list, []),
-        ld_sections_blacklist=p.parse_opt("ld_sections_blacklist", list, []),
+        ld_sections_allowlist=p.parse_opt("ld_sections_allowlist", list, []),
+        ld_sections_denylist=p.parse_opt("ld_sections_denylist", list, []),
         ld_section_labels=p.parse_opt(
             "ld_section_labels",
             list,


### PR DESCRIPTION
2 new options to fine-tune the linker script generation. Both are a whitelist and a blacklist of sections to discard during linktime.
This can be useful to preserve debugging symbols on the final elf