### PR TITLE
Move wiki to `docs` folder

### DIFF
--- a/.github/workflows/publish_docs_to_wiki.yml
+++ b/.github/workflows/publish_docs_to_wiki.yml
@@ -1,0 +1,45 @@
+name: Publish docs to Wiki
+
+# Trigger this action only if there are changes pushed to the docs/** directory under the main branch
+on:
+  push:
+    paths:
+      - docs/** # This includes all sub folders
+    branches:
+      - main # This can be changed to any branch of your preference
+
+env:
+  USER_TOKEN: ${{ secrets.WIKI_ACTION_TOKEN }} # This is the repository secret
+  USER_NAME: <USERNAME> # Enter the username of your (bot) account
+  USER_EMAIL: <EMAIL> # Enter the e-mail of your (bot) account
+  OWNER: ${{ github.event.repository.owner.name }} # This is the repository owner
+  REPOSITORY_NAME: ${{ github.event.repository.name }} # This is the repository name
+
+jobs:
+  publish_docs_to_wiki:
+    name: Publish docs to Wiki
+    runs-on: ubuntu-latest
+    steps:  
+      - name: Checkout repository
+      - uses: actions/checkout@v2
+
+      # 1. Create folder named `tmp_wiki`
+      # 2. Initialize Git
+      # 3. Pull old Wiki content
+      - name: Pull content from wiki
+        run: |
+          mkdir tmp_wiki
+          cd tmp_wiki
+          git init
+          git config user.name $USER_NAME
+          git config user.email $USER_EMAIL
+          git pull https://$USER_TOKEN@github.com/$OWNER/$REPOSITORY_NAME.wiki.git
+      # 4. Synchronize differences between `docs` & `tmp_wiki`
+      # 5. Push new Wiki content
+      - name: Push content to wiki
+        run: |
+          rsync -av --delete docs/ tmp_wiki/ --exclude .git
+          cd tmp_wiki
+          git add .
+          git commit -m "Update Wiki content" 
+          git push -f --set-upstream https://$USER_TOKEN@github.com/$OWNER/$REPOSITORY_NAME.wiki.git master

--- a/.github/workflows/publish_docs_to_wiki.yml
+++ b/.github/workflows/publish_docs_to_wiki.yml
@@ -1,4 +1,4 @@
-# Taken from https://nimblehq.co/blog/create-github-wiki-pull-request
+# Based on script from https://github.com/orgs/community/discussions/25929
 
 name: Publish docs to Wiki
 
@@ -11,7 +11,7 @@ on:
       - main # This can be changed to any branch of your preference
 
 env:
-  USER_TOKEN: ${{ secrets.WIKI_ACTION_TOKEN }} # This is the repository secret
+#   USER_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is the repository secret
   OWNER: ${{ github.event.repository.owner.name }} # This is the repository owner
   REPOSITORY_NAME: ${{ github.event.repository.name }} # This is the repository name
 
@@ -20,29 +20,40 @@ jobs:
     name: Publish docs to Wiki
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-      - uses: actions/checkout@v4
+    # Clone the wiki repository
+    - name: Checkout Wiki repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.event.repository.name }}.wiki
+        path: wiki_repo
 
-      # 1. Create folder named `tmp_wiki`
-      # 2. Initialize Git
-      # 3. Pull old Wiki content
-      # `git log -1 --pretty=%aN` prints the current commit's author name
-      # `git log -1 --pretty=%aE` prints the current commit's author mail
-      - name: Pull content from wiki
-        run: |
-          mkdir tmp_wiki
-          cd tmp_wiki
-          git init
-          git config user.name $(git log -1 --pretty=%aN)
-          git config user.email $(git log -1 --pretty=%aE)
-          git pull https://$USER_TOKEN@github.com/$OWNER/$REPOSITORY_NAME.wiki.git
-      # 4. Synchronize differences between `docs` & `tmp_wiki`
-      # 5. Push new Wiki content
-      # `git log -1 --pretty=%B` prints the current commit's message
-      - name: Push content to wiki
-        run: |
-          rsync -av --delete docs/ tmp_wiki/ --exclude .git
-          cd tmp_wiki
-          git add .
-          git commit -m "$(git log -1 --pretty=%B)"
-          git push -f --set-upstream https://$USER_TOKEN@github.com/$OWNER/$REPOSITORY_NAME.wiki.git master
+    # Clone the main repository
+    - name: Checkout main repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.event.repository.name }}
+        path: splat_repo
+
+    - name: Get the new Wiki files
+      run: |
+        cd wiki_repo
+        rm *.md
+        cp ../splat_repo/docs/* .
+
+    # `git log -1 --pretty=%aN` prints the current commit's author name
+    # `git log -1 --pretty=%aE` prints the current commit's author mail
+    - name: Stage new files
+      run: |
+        cd wiki_repo
+        git config user.name $(git log -1 --pretty=%aN)
+        git config user.email $(git log -1 --pretty=%aE)
+        git add .
+
+    # `git diff-index --quiet HEAD` returns non-zero if there are any changes.
+    # This allows to avoid making a commit/push if there are no changes to the Wiki files
+
+    # `git log -1 --pretty=%B` prints the current commit's message
+    - name: Push new files to the Wiki
+      run: |
+        cd wiki_repo
+        git diff-index --quiet HEAD || (git commit -m "$(git log -1 --pretty=%B)" && git push)

--- a/.github/workflows/publish_docs_to_wiki.yml
+++ b/.github/workflows/publish_docs_to_wiki.yml
@@ -1,3 +1,5 @@
+# Taken from https://nimblehq.co/blog/create-github-wiki-pull-request
+
 name: Publish docs to Wiki
 
 # Trigger this action only if there are changes pushed to the docs/** directory under the main branch
@@ -10,8 +12,6 @@ on:
 
 env:
   USER_TOKEN: ${{ secrets.WIKI_ACTION_TOKEN }} # This is the repository secret
-  USER_NAME: <USERNAME> # Enter the username of your (bot) account
-  USER_EMAIL: <EMAIL> # Enter the e-mail of your (bot) account
   OWNER: ${{ github.event.repository.owner.name }} # This is the repository owner
   REPOSITORY_NAME: ${{ github.event.repository.name }} # This is the repository name
 
@@ -19,27 +19,30 @@ jobs:
   publish_docs_to_wiki:
     name: Publish docs to Wiki
     runs-on: ubuntu-latest
-    steps:  
+    steps:
       - name: Checkout repository
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # 1. Create folder named `tmp_wiki`
       # 2. Initialize Git
       # 3. Pull old Wiki content
+      # `git log -1 --pretty=%aN` prints the current commit's author name
+      # `git log -1 --pretty=%aE` prints the current commit's author mail
       - name: Pull content from wiki
         run: |
           mkdir tmp_wiki
           cd tmp_wiki
           git init
-          git config user.name $USER_NAME
-          git config user.email $USER_EMAIL
+          git config user.name $(git log -1 --pretty=%aN)
+          git config user.email $(git log -1 --pretty=%aE)
           git pull https://$USER_TOKEN@github.com/$OWNER/$REPOSITORY_NAME.wiki.git
       # 4. Synchronize differences between `docs` & `tmp_wiki`
       # 5. Push new Wiki content
+      # `git log -1 --pretty=%B` prints the current commit's message
       - name: Push content to wiki
         run: |
           rsync -av --delete docs/ tmp_wiki/ --exclude .git
           cd tmp_wiki
           git add .
-          git commit -m "Update Wiki content" 
+          git commit -m "$(git log -1 --pretty=%B)"
           git push -f --set-upstream https://$USER_TOKEN@github.com/$OWNER/$REPOSITORY_NAME.wiki.git master

--- a/docs/Adding-Symbols.md
+++ b/docs/Adding-Symbols.md
@@ -1,0 +1,144 @@
+Symbols (i.e. labelling a function or variable) are controlled by the `symbols_addrs.txt` file. 
+
+The format for defining symbols is:
+
+```ini
+symbol = address; // option1:value1 option2:value2
+```
+e.g.
+```ini
+osInitialize = 0x801378C0; // type:func
+```
+
+:information_source: The file used can be overridden via the `symbol_addrs_path` setting in the global `options` section of the splat yaml. This option can also accept multiple paths, allowing to organize symbols in multiple files.
+
+## symbol
+
+This is the name of the symbol and can be any valid C variable name, e.g. `myCoolFunction` or `gReticulatedSplineCounter`
+
+## address
+
+This is the VRAM address expressed in hexadecimal, e.g. `0x80001050`
+
+## options
+
+An optional `key:pair` list of settings, note that each option should be separated by whitespace, but there should be no whitespace between the key:value pairs themselves.
+
+### `type`
+
+Override splat's automatic type detection, possible values are:
+- `func`: Functions
+- `jtbl`: Jumptables
+- `jtbl_label`: Jumptables labels (inside functions)
+- `label`: Branch labels (inside functions)
+- `s8`, `u8`: To specify data/rodata to be disassembled as `.byte`s
+- `s16`, `u16`: To specify data/rodata to be disassembled as `.short`s
+- `s32`, `u32`: To specify data/rodata to be disassembled as `.word`s (the default)
+- `s64`, `u64`: :man_shrugging: 
+- `f32`, `Vec3f`: To specify data/rodata to be disassembled as `.float`s
+- `f64`: To specify data/rodata to be disassembled as `.double`s
+- `asciz`, `char*`, `char`: C strings (disassembled as `.asciz`)
+- Any custom type starting with a capital letter (will default to `.word`s)
+
+Any other type will produce an error.
+
+**Example:**
+```ini
+minFrameSize = 0x80241D08; // type:s32
+```
+
+### `size`
+
+The size of the function or the size of the data depending on the type of the symbol. It specifies a size in bytes. e.g. `size:0x10`.
+
+**Example:**
+```ini
+RawHuffmanTable = 0x8022E0E0; // type:symbol size:0x100
+```
+
+### `rom`
+
+The ROM offset for the symbol, useful (potentially mandatory) for symbols in overlays where multiple symbols could share the same VRAM address.
+
+**Example:**
+```ini
+create_particle_effect = 0x802D5F4C; // type:func rom:0x6E75FC
+```
+
+### `segment`
+
+Allows specifying to which specific segment this symbol belongs to, useful to disambiguate symbols from segments that share the same VRAM address. This name must be the same as the name of a segment listed in the yaml.
+
+**Example:**
+```ini
+sMenuTexture = 0x06004040; // segment:menu_assets
+```
+
+### `name_end`
+
+Emits a symbol after the end of the data of the current symbol. Useful to reference the end of an assembly symbol, like RSP data.
+
+**Example:**
+```ini
+rspbootTextStart = 0x80084690; // name_end:rspbootTextEnd
+```
+
+### `appears_after_overlays_addr`
+
+TBD
+
+### `dead`
+
+TBD
+
+### `defined`
+
+Forces the symbol to be defined - i.e. prevent it from appearing in `undefined_syms_auto.txt` should splat not encounter the symbol during the symbol detection phase.
+
+**Example:**
+```ini
+__osDpDeviceBusy = 0x8014B3D0; // defined:true
+```
+
+### `extract`
+
+TBD
+
+### `ignore`
+
+Prevents an address from being symbolized and referenced. Useful to get a finer control over the disassembled output.
+
+**Example:**
+```ini
+D_A0000000 = 0xA0000000; // ignore:true
+```
+
+It can also be combined with the `size` attribute to avoid a range of addresses of being symbolized.
+
+**Example:**
+```ini
+D_80000000 = 0x80000000; // ignore:true size:0x10
+```
+
+### `force_migration` and `force_not_migration`
+
+Grants a finer control over the automatic rodata migration to functions. This may be required because of the migration heuristic failing to migrate (or to not migrate) a symbol, producing a disordered rodata section. Forcing the migration of a rodata symbol to a function will only work if that function references said rodata symbol. Forcing the not-migration of a rodata symbol always works.
+
+This attribute is ignored if the `migrate_rodata_to_functions` option is disabled.
+
+**Example:**
+```ini
+jtbl_800B13D0 = 0x800B13D0; // type:jtbl force_migration:True
+STR_800B32A8 = 0x800C9520; // type:asciz force_not_migration:True
+```
+
+### `allow_addend` and `dont_allow_addend`
+
+Allows this symbol to reference (or not reference) other symbols with an addend.
+
+This attribute overrides the global `allow_data_addends` option.
+
+**Example:**
+```ini
+aspMainTextStart = 0x80084760; // dont_allow_addend:True
+```

--- a/docs/Advanced.md
+++ b/docs/Advanced.md
@@ -1,0 +1,6 @@
+## Writing custom segment handler
+
+The following list contains examples of custom segments:
+
+- [RNC](https://github.com/mkst/sssv/blob/master/tools/splat_ext/rnc.py)
+- [Vtx](https://github.com/mkst/sssv/blob/master/tools/splat_ext/sssv_vtx.py)

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,0 +1,586 @@
+Splat has various options for configuration, all of which are listed under the `options` section of the yaml file.
+
+## Project configuration
+
+### base_path
+
+Path that all other configured paths are relative to.
+
+#### Usage
+
+```yaml
+base_path: path/to/base/folder
+```
+
+#### Default
+
+`.`
+
+
+### target_path
+
+Path to target binary.
+
+#### Usage
+
+```yaml
+target_path: path/to/target/binary
+```
+
+### elf_path
+
+Path to the final elf target
+
+#### Default
+Path to the binary that was used as the input to `create_config.py`
+
+
+### platform
+
+The target platform for the binary. Options are 
+- `n64` (Nintendo 64)
+- `psx` (PlayStation 1)
+- `ps2` (PlayStation 2)
+- `gc` (GameCube)
+
+#### Usage
+```yaml
+platform: psx
+```
+
+
+### compiler
+
+Compiler used to build the binary.
+
+splat recognizes the following compilers, and it will adapt it behavior accordingly for them, but unknown compilers can be passed as well:
+- GCC
+- SN64
+- IDO
+
+#### Usage
+```yaml
+compiler: IDO
+```
+
+#### Default
+`ido`
+
+
+### endianness
+
+Determines the endianness of the target binary. If not set, the endiannesss will be guessed from the selected platform.
+
+Valid values:
+- big
+- little
+
+
+### section_order
+
+Determines the default section order of the target binary. This can be overridden per-segment.
+
+Expects a list of strings.
+
+
+### generated_c_preamble
+
+String that is placed before the contents of newly-generated `.c` files.
+
+#### Usage
+
+```yaml
+generated_c_preamble: #include "header.h"
+```
+
+#### Default
+
+`#include "common.h"`
+
+
+### generated_s_preamble
+
+String that is placed before the contents of newly-generated assembly (`.s`) files.
+
+#### Usage
+
+```yaml
+generated_s_preamble: .set fp=64
+```
+
+
+### o_as_suffix
+
+Determines whether to replace the suffix of the file to `.o` or to append `.o` to the suffix of the file.
+
+
+### gp_value
+
+The value of the `$gp` register to correctly calculate offset to `%gp_rel` relocs.
+
+
+## Paths
+
+
+### asset_path
+
+Path to output split asset files.
+
+#### Usage
+
+```yaml
+asset_path: path/to/assets/folder
+```
+
+#### Default
+
+`assets`
+
+
+### symbol_addrs_path
+
+Determines the path to the symbol addresses file(s). A `symbol_addrs` file is to be updated/curated manually and contains addresses of symbols as well as optional metadata such as rom address, type, and more
+
+It's possible to use more than one file by supplying a list instead of a string
+
+#### Usage
+```yaml
+symbol_addrs_path: path/to/symbol_addrs
+```
+
+#### Default
+`symbol_addrs.txt`
+
+
+
+### reloc_addrs_paths
+
+
+
+### build_path
+Path that built files will be found. Used for generation of the linker script.
+
+#### Usage
+```yaml
+build_path: path/to/build/folder
+```
+
+#### Default
+`build`
+
+
+### src_path
+Path to split `.c` files.
+
+#### Usage
+```yaml
+src_path: path/to/src/folder
+```
+
+#### Default
+`src`
+
+
+### asm_path
+Path to output split assembly files.
+
+#### Usage
+```yaml
+asm_path: path/to/asm/folder
+```
+
+#### Default
+`asm`
+
+
+### data_path
+
+Determines the path to the asm data directory
+
+
+### nonmatchings_path
+
+Determines the path to the asm nonmatchings directory
+
+
+### cache_path
+Path to splat cache
+
+#### Usage
+```yaml
+cache_path: path/to/splat/cache
+```
+
+#### Default
+`.splat_cache`
+
+
+### create_undefined_funcs_auto
+If `True`, splat will generate an `undefined_funcs_auto.txt` file.
+
+#### Usage
+```yaml
+create_undefined_funcs_auto: False
+```
+
+#### Default
+`True`
+
+
+### undefined_funcs_auto_path
+Path to file containing automatically defined functions.
+
+#### Usage
+```yaml
+undefined_funcs_auto_path: path/to/undefined_funcs_auto.txt
+```
+
+#### Default
+`undefined_funcs_auto.txt`
+
+
+
+### create_undefined_syms_auto
+If `True`, splat will generate an `undefined_syms_auto.txt` file.
+
+#### Usage
+```yaml
+create_undefined_syms_auto: False
+```
+
+#### Default
+`True`
+
+
+### undefined_syms_auto_path
+Path to file containing automatically defined symbols.
+
+#### Usage
+```yaml
+undefined_syms_auto_path: path/to/undefined_syms_auto.txt
+```
+
+#### Default
+`undefined_syms_auto.txt`
+
+
+### extensions_path
+If you are using splat extension(s), this is the path they will be loaded from.
+
+#### Usage
+```yaml
+extensions_path: path/to/extensions/folder
+```
+
+#### Default
+`tools/splat_ext`
+
+
+### lib_path
+
+Determines the path to library files that are to be linked into the target binary
+
+
+### elf_section_list_path
+Path to file containing elf section list.
+
+#### Usage
+```yaml
+elf_section_list_path: path/to/elf_sections
+```
+
+#### Default
+`elf_sections.txt`
+
+
+## Linker script
+
+
+### subalign
+
+Sub-alignment (in bytes) of sections.
+
+#### Usage
+```yaml
+subalign: 4
+```
+
+#### Default
+`16`
+
+
+### auto_all_sections
+
+TODO
+
+### ld_script_path
+
+Path to output ld script.
+
+#### Usage
+
+```yaml
+ld_script_path: path/to/ld/script.ld
+```
+
+#### Default
+
+`{basename}.ld`
+
+
+### ld_symbol_header_path
+
+Path to output a header containing linker symbols.
+
+#### Usage
+```yaml
+ld_symbol_header_path: path/to/linker_symbol_header
+```
+
+### ld_discard_section
+
+Determines whether to add a discard section to the linker script
+
+### ld_section_labels
+
+Determines the list of section labels that are to be added to the linker script
+
+### ld_wildcard_sections
+
+Determines whether to add wildcards for section linking in the linker script (.rodata* for example)
+
+### ld_use_follows
+
+Determines whether to use "follows" settings to determine locations of overlays in the linker script.
+If disabled, this effectively ignores "follows" directives in the yaml.
+
+### ld_partial_linking
+
+Change linker script generation to allow partially linking segments. Requires both `ld_partial_scripts_path` and `ld_partial_build_segments_path` to be set.
+
+### ld_partial_scripts_path
+
+Folder were each intermediary linker script will be written to.
+
+### ld_partial_build_segments_path
+
+Folder where the built partially linked segments will be placed by the build system.
+
+### ld_dependencies
+
+Generate a dependency file for every linker script generated. Dependency files will have the same path and name as the corresponding linker script, but changing the extension to `.d`. Requires `elf_path` to be set.
+
+### ld_legacy_generation
+
+Legacy linker script generation does not impose the section_order specified in the yaml options or per-segment options.
+
+### segment_end_before_align
+
+If enabled, the end symbol for each segment will be placed before the alignment directive for the segment
+
+### segment_symbols_style
+
+Controls the style of the auto-generated segment symbols in the linker script.
+
+Possible values:
+- splat
+- makerom
+
+
+### ld_rom_start
+
+Specifies the starting offset for rom address symbols in the linker script.
+
+
+## C file options
+
+### create_c_files
+
+Determines whether to create new c files if they don't exist
+
+### auto_decompile_empty_functions
+
+Determines whether to "auto-decompile" empty functions
+
+### do_c_func_detection
+
+Determines whether to detect matched/unmatched functions in existing c files so we can avoid creating `.s` files for already-decompiled functions.
+
+### c_newline
+
+Determines the newline char(s) to be used in c files
+
+
+## (Dis)assembly-related options
+
+### symbol_name_format
+
+Determine the format that symbols should be named by default
+
+### symbol_name_format_no_rom
+
+Same as `symbol_name_format` but for symbols with no rom address
+
+### find_file_boundaries
+
+Determines whether to detect and hint to the user about likely file splits when disassembling
+
+### pair_rodata_to_text
+
+Determines whether to detect and hint to the user about possible rodata sections corresponding to a text section
+
+### migrate_rodata_to_functions
+
+Determines whether to attempt to automatically migrate rodata into functions
+
+### asm_inc_header
+
+Determines the header to be used in every asm file that's included from c files
+
+### asm_function_macro
+
+Determines the macro used to declare functions in asm files
+
+### asm_function_alt_macro
+
+Determines the macro used to declare symbols in the middle of functions in asm files (which may be alternative entries)
+
+### asm_jtbl_label_macro
+
+Determines the macro used to declare jumptable labels in asm files
+
+### asm_data_macro
+
+Determines the macro used to declare data symbols in asm files
+
+### asm_end_label
+
+Determines the macro used at the end of a function, such as endlabel or .end
+
+### asm_emit_size_directive
+
+Toggles the .size directive emitted by the disassembler
+
+### include_macro_inc
+
+Determines including the macro.inc file on non-migrated rodata variables
+
+### mnemonic_ljust
+
+Determines the number of characters to left align before the instruction
+
+### rom_address_padding
+
+Determines whether to pad the rom address
+
+### mips_abi_gpr
+
+Determines which ABI names to use for general purpose registers
+
+### mips_abi_float_regs
+
+Determines which ABI names to use for floating point registers.
+
+Valid values:
+- numeric
+- o32
+- n32
+- n64
+
+`o32`` is highly recommended, as it provides logically named registers for floating point instructions.
+For more info, see https://gist.github.com/EllipticEllipsis/27eef11205c7a59d8ea85632bc49224d
+
+### add_set_gp_64
+
+Determines whether to add ".set gp=64" to asm/hasm files
+
+### create_asm_dependencies
+
+Generate `.asmproc.d` dependency files for each C file which still reference functions in assembly files
+
+### string_encoding
+
+Global option for rodata string encoding. This can be overriden per segment
+
+### data_string_encoding
+
+Global option for data string encoding. This can be overriden per segment
+
+### rodata_string_guesser_level
+
+Global option for the rodata string guesser. 0 disables the guesser completely.
+
+### data_string_guesser_level
+
+Global option for the data string guesser. 0 disables the guesser completely.
+
+### allow_data_addends
+
+Global option for allowing data symbols using addends on symbol references. It can be overriden per symbol
+
+### disasm_unknown
+
+Tells the disassembler to try disassembling functions with unknown instructions instead of falling back to disassembling as raw data
+
+### detect_redundant_function_end
+
+Tries to detect redundant and unreferenced functions ends and merge them together. This option is ignored if the compiler is not set to IDO.
+
+### disassemble_all
+
+Don't skip disassembling already matched functions and migrated sections
+
+
+## N64-specific options
+
+### header_encoding
+
+Used to specify what encoding should be used used when parsing the N64 ROM header.
+
+#### Default
+
+`ASCII`
+
+
+### gfx_ucode
+
+Determines the type gfx ucode (used by gfx segments)
+
+Valid options are:
+- f3d
+- f3db
+- f3dex
+- f3dexb
+- f3dex2
+
+### libultra_symbols
+
+Use named libultra symbols by default. Those will need to be added to a linker script manually by the user
+
+### ique_symbols
+
+Use named libultra symbols by default. Those will need to be added to a linker script manually by the user
+
+### hardware_regs
+
+Use named hardware register symbols by default. Those will need to be added to a linker script manually by the user
+
+
+## Gamecube-specific options
+
+### filesystem_path
+
+Path where the iso's filesystem will be extracted to
+
+## Compiler-specific options
+
+### use_legacy_include_asm
+If `True`, generate c files using the longer `INCLUDE_ASM` macro. This is defaulted to `True` to by-default support projects using the longer macro.
+
+#### Usage
+```yaml
+use_legacy_include_asm: False
+```
+
+#### Default
+`True`

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -1,0 +1,22 @@
+The following is a list of projects known to be using **splat** along with the compilers used:
+
+## N64 Projects
+- [Aidyn Chronicles](https://github.com/blackgamma7/Aidyn) `unknown` (does not build source)
+- [Banjo Kazooie](https://gitlab.com/banjo.decomp/banjo-kazooie) `ido5.3`
+- [Conker's Bad Fur Day](https://github.com/mkst/conker) `ido5.3`
+- [Dinosaur Planet](https://github.com/zestydevy/dinosaur-planet) `ido5.3`
+- [Gauntlet Legends](https://github.com/Drahsid/gauntlet-legends) `kmc gcc2.7.2` (uses old KMC GCC wrapper - do not use for reference)
+- [Mario Party 3](https://github.com/PartyPlanner64/mp3) `gcc2.7.2 TBD`
+- [Mischief Makers](https://github.com/Drahsid/mischief-makers) `ido5.3`
+- [Neon Genesis Evangelion 64](https://github.com/farisawan-2000/evangelion) `kmc gcc2.7.2`
+- [Paper Mario](https://github.com/pmret/papermario) `gcc2.8.1`
+- [Pokemon Snap](https://github.com/ethteck/pokemonsnap) `ido7.1`
+- [Pokemon Stadium](https://github.com/ethteck/pokemonstadium) `ido7.1`
+- [Rocket Robot on Wheels](https://github.com/RocketRet/Rocket-Robot-On-Wheels) `SN64 (build 970404)`
+- [Space Station Silicon Valley](https://github.com/mkst/sssv) `ido5.3`
+- [Turok 3](https://github.com/drahsid/turok3) `psyq gcc2.8.0`
+
+## PS1 Projects
+- [Evo's Space Adventures](https://github.com/mkst/esa) `psyq 4.6 (gcc2.95)`
+- [Final Fantasy 7](https://github.com/Drahsid/ffvii) `psyq <= 4.1 (gcc2.7.2)`
+- [Silent Hill](https://github.com/Vatuu/silent-hill-decomp) `psyq <= 4.1 (gcc2.7.2) TBD`

--- a/docs/General-Workflow.md
+++ b/docs/General-Workflow.md
@@ -1,0 +1,82 @@
+This describes an example of how to iteratively edit the splat segments config, when decompiling
+
+# 1 Initially
+
+Assuming that after you split segments you start from a code segment which subsegments include
+```yaml
+- [0x42100, bin]
+```
+
+# 2 Disassemble text, data, rodata
+
+To start decompiling this subsegment, replace it with
+```yaml
+- [0x42100, c, energy_orb_wave]
+- [0x42200, data, energy_orb_wave]
+- [0x42300, rodata, energy_orb_wave]
+```
+
+This will disassemble `0x42100-0x42200` to individual `.s` files for each function found
+
+It will also write `energy_orb_wave.data.s` and `energy_orb_wave.rodata.s` (using information gained during the disassembly of the functions)
+
+And if the project uses asm-processor, write a .c with `GLOBAL_ASM()` to include all disassembled functions.
+
+Figuring out the data and rodata addresses is to be done manually. Just disassembling the whole segment may help:
+```yaml
+- [0x42100, c, energy_orb_wave]
+```
+to locate data
+
+# 3 Decompile text
+
+This involved back and forth between `.c` and `.s` files:
+
+- editing the `data.s`, `rodata.s` files to add/fixup symbols at the proper locations
+- decompiling functions, declaring symbols (`extern`s) in the `.c`
+
+The linker script links
+- `.text` (only) from the .o built from `energy_orb_wave.c`
+- `.data` (only) from the .o built from `energy_orb_wave.data.s`
+- `.rodata` (only) from the .o built from `energy_orb_wave.rodata.s`
+
+.data (respectively .rodata) is not linked from the .o built from `energy_orb_wave.c`, because the subsegments include segments with the `data` (respectively `rodata`) segment type
+
+# 4 Decompile data
+
+Move (decompile) data/rodata to the .c, using structs or relying on strings used in the code, or other things
+
+Again, the .data/.rodata sections from the .o built from the .c will not be linked as long as there are any `data`/`rodata` subsegment in the code segment (and not just for `energy_orb_wave`, any other subsegment too)
+
+To link the .data/.rodata from the .o built from the .c (instead of from the .s files), the subsegments should be changed from
+
+```yaml
+- [0x42100, c, energy_orb_wave]
+- [0x42200, data, energy_orb_wave]
+- [0x42300, rodata, energy_orb_wave]
+```
+
+to
+
+```yaml
+- [0x42100, c, energy_orb_wave]
+- [0x42200, .data, energy_orb_wave]
+- [0x42300, .rodata, energy_orb_wave]
+```
+
+If using `auto_all_section` and there is no other `data`/`.data`/`rodata`/`.rodata` in the subsegments in the code segment, the subsegments can also be changed to
+
+```yaml
+- [0x42100, c, energy_orb_wave]
+- [0x42200]
+```
+
+# 5 Done!
+
+`.text`, `.data` and `.rodata` are linked from the .o built from `energy_orb_wave.c` which now has everything to match when building
+
+The assembly files (functions .s, data.s and rodata.s files) can be deleted
+
+# BSS
+
+Note: this explanation lacks .bss handling

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,0 +1,23 @@
+### What is splat?
+
+**splat** is a binary splitting tool, written in Python.
+
+It is the spiritual successor to [n64split](https://github.com/queueRAM/sm64tools/blob/master/n64split.c). Originally written to handle N64 ROMs, it also has limited support for PSX binaries.
+
+MIPS code disassembly is handled via [spimdisasm](https://github.com/Decompollaborate/spimdisasm/).
+
+There are a number of asset types built-in (e.g. various image formats, N64 Vtx data, etc), and it is designed to be simple to write your own custom types that can do anything you want and fit right into the splat pipeline.
+
+
+### How does it work?
+
+**splat** takes a [yaml](https://en.wikipedia.org/wiki/YAML) configuration file which tell it *where* and *how* to split a given file. Splat loads the yaml and an optional "symbol_addrs" file that can give it information about symbols that will be used during disassembly. It then runs the two main phases: scan and split. 
+
+The scan phase is for making a first pass over the data and for doing initial disassembly. During the split phase, information gathered during the scan phase is used and files are written out to disk.
+
+After scanning and splitting, splat will output a linker script that can be used to re-build the input file.
+
+
+### Sounds great, how do I get started?
+
+Have a look at the [Quickstart](https://github.com/ethteck/splat/wiki/Quickstart), or check out the [Examples](https://github.com/ethteck/splat/wiki/Examples) page to see projects that are using **splat**.

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -1,0 +1,150 @@
+> **Note**: This quickstart is written with N64 ROMs in mind, and the assumption that you are using Ubuntu 20.04 either natively, via WSL2 or via Docker.
+
+For the purposes of this quickstart, we will assume that we are going to split a game called `mygame` and we have the ROM in `.z64` format named `baserom.z64`.
+
+Create a directory for `~/mygame` and `cd` into it:
+
+```sh
+mkdir -p ${HOME}/mygame && cd ${HOME}/mygame
+```
+
+Copy the `baserom.z64` file into the `mygame` directory inside your home directory.
+
+### System packages
+
+#### Python 3.8
+
+Ensure you are have **Python 3.8** or higher installed:
+
+```sh
+$ python3 --version
+Python 3.8.10
+```
+
+If you get `bash: python3: command not found` install it with the following command:
+
+```sh
+sudo apt-get update && sudo apt-get install -y python3 python3-pip
+```
+
+#### Git
+
+Ensure you have **git**:
+
+```sh
+$ git --version
+```
+
+If you get `bash: git: command not found`, install it with the following command:
+
+```sh
+sudo apt-get update && sudo apt-get install -y git
+```
+
+## Checkout the repository
+
+We will clone **splat** into a `tools` directory to keep things organised:
+
+```sh
+git clone https://github.com/ethteck/splat.git tools/splat
+```
+
+## Python packages
+
+Run the following to install the prerequisite Python packages:
+
+```sh
+python3 -m pip install -r ./tools/splat/requirements.txt
+```
+
+## Create a config file for your baserom
+
+**splat** has a script that will generate a `yaml` file for your ROM.
+
+```sh
+python3 tools/splat/create_config.py baserom.z64
+```
+
+The `yaml` file generated will be named based upon the name of the ROM (taken from its header). The example below is for Super Mario 64:
+
+```yaml
+$ cat supermario64.yaml
+name: Super Mario 64 (North America)
+sha1: 9bef1128717f958171a4afac3ed78ee2bb4e86ce
+options:
+  basename: supermario64
+  target_path: baserom.z64
+  base_path: .
+  compiler: IDO
+  find_file_boundaries: True
+  # platform: n64
+  # undefined_funcs_auto_path: undefined_funcs_auto.txt
+  # undefined_syms_auto_path: undefined_syms_auto.txt
+  # symbol_addrs_path: symbol_addrs.txt
+  # undefined_syms_path: undefined_syms.txt
+  # asm_path: asm
+  # src_path: src
+  # build_path: build
+  # extensions_path: tools/splat_ext
+  # auto_all_sections: True
+segments:
+  - name: header
+    type: header
+    start: 0x0
+  - name: boot
+    type: bin
+    start: 0x40
+  - name: main
+    type: code
+    start: 0x1000
+    vram: 0x80246000
+    subsegments:
+      - [0x1000, asm]
+  - type: bin
+    start: 0xE6430
+  - [0x800000]
+```
+
+This is a bare-bones configuration and there is a lot of work required to map out the different sections of the ROM.
+
+## Run splat with your configuration
+
+```sh
+python3 tools/splat/split.py supermario64.yaml
+```
+
+The output will look something like this:
+```
+splat 0.7.10.1
+Loading and processing symbols
+Starting scan
+..Segment 1000, function at vram 80246DF8 ends with extra nops, indicating a likely file split.
+File split suggestions for this segment will follow in config yaml format:
+      - [0x1E70, asm]
+      - [0x3C40, asm]
+      - [0x45E0, asm]
+      - [0x6FF0, asm]
+#     < -- snip -->
+      - [0xE6060, asm]
+      - [0xE61F0, asm]
+      - [0xE6200, asm]
+      - [0xE6260, asm]
+..
+Starting split
+....
+Split 943 KB (11.24%) in defined segments
+              header:     64 B (0.00%) 1 split, 0 cached
+                 bin:     4 KB (0.05%) 1 split, 0 cached
+                code:   939 KB (11.19%) 1 split, 0 cached
+             unknown:     7 MB (88.76%) from unknown bin files
+```
+
+Notice that **splat** has found some potential file splits (function start/end with 16 byte alignment padded with nops).
+
+It's up to you to figure out the layout of the ROM.
+
+## Next Steps
+
+The reassembly of the ROM is currently out of scope of this quickstart, as is switching out the `asm` segments for `c`.
+
+Please feel free to improve this guide!

--- a/docs/Segments.md
+++ b/docs/Segments.md
@@ -1,0 +1,149 @@
+The configuration file for **splat** consists of a number of well-defined segments.
+
+Most segments can be defined as a dictionary or a list, but the list syntax is only suitable for very simple cases and doesn't allow for specifying most of the options a segment type has to offer.
+
+Splat segments' behavior generally falls under two categories: extraction and linking. Some segments will only do extraction, some will only do linking, some both, and some neither. Generally, segments both will describe extraction and linking behavior. Additionally, a segment type whose name starts with a dot (.) will only focus on linking. 
+
+## `asm`
+
+**Description:**
+
+Segments designated Assembly, `asm`, will be disassembled via Capstone and then enriched with Symbols based on the contents of `symbol_addrs`.
+
+**Example:**
+
+```yaml
+# as list
+- [0xABC, asm, filepath1]
+- [0xABC, asm, dir1/filepath2]  # this will create filepath2.s inside a directory named dir1
+
+# as dictionary
+- name: filepath
+  type: asm
+  start: 0xABC
+```
+
+### `hasm`
+
+**Description:**
+
+Hand-written Assembly, `hasm`, similar to `asm` except it will not overwrite any existing files.
+
+**Example:**
+
+```yaml
+# as list
+- [0xABC, hasm, filepath]
+
+# as dictionary
+- name: filepath
+  type: hasm
+  start: 0xABC
+```
+
+## `bin`
+
+**Description:**
+
+The 'binary' segment type is for 'raw' data, or data where the type is yet to be determined.
+
+**Example:**
+
+```yaml
+# as list
+- [0xABC, bin, filepath]
+
+# as dictionary
+- name: filepath
+  type: bin
+  start: 0xABC
+```
+
+## `code`
+
+**Description:**
+
+The 'code' segment type, `code` is a group that can have many `subsegments`.
+
+**Example:**
+
+```yaml
+# must be a dictionary
+- name:  main
+  type:  code
+  start: 0x00001000
+  vram:  0x80125900
+  subsegments:
+    - [0x1000, asm, entrypoint]
+    - [0x1050, c, main]
+```
+
+## `c`
+
+**Description:**
+
+The C code segments have two behaviors:
+- If the target `.c` file does not exist, a new file will be generated with macros to include the original Assembly (macros differ for IDO vs GCC compiler).
+- Otherwise the target `.c` file is scanned to determine what assembly needs to be extracted from the ROM.
+
+Assembly that is extracted due to a `c` segment will be written to a `nonmatching` folder, with one function per file.
+
+**Example:**
+
+```yaml
+# as list
+- [0xABC, c, filepath]
+
+# as dictionary
+- name: filepath
+  type: c
+  start: 0xABC
+```
+
+## `header`
+
+**Description:**
+
+This is platform specific; parses the data and interprets as a header for e.g. N64 or PS1 elf.
+
+**Example:**
+
+```yaml
+# as list
+- [0xABC, header, filepath]
+
+# as dictionary
+- name: filepath
+  type: header
+  start: 0xABC
+```
+
+## Images
+
+**Description:**
+
+**splat** supports most of the [N64 image formats](https://n64squid.com/homebrew/n64-sdk/textures/image-formats/):
+
+- `i`, i.e. `i4` and `i8`
+- `ia`, i.e. `ia4`, `ia8`, and `ia16`
+- `ci`, i.e. `ci4` and `ci8`
+- `rgb`, i.e. `rgba32` and `rgba16`
+
+These segments will parse the image data and dump out a `png` file.
+
+**Note:** Using the dictionary syntax allows for richer configuration.
+
+**Example:**
+
+```yaml
+# as list
+- [0xABC, i4, filename, width, height]
+# as a dictionary
+- name: filename
+  type: i4
+  start: 0xABC
+  width: 64
+  height: 64
+  flip_x: yes
+  flip_y: no
+```


### PR DESCRIPTION
Moves the wiki to a docs folder and publishes it automatically to the actual wiki using a Github Action.

I followed the tutorial from https://nimblehq.co/blog/create-github-wiki-pull-request

Please note this PR should **not** be merged until the repo has a secret named `WIKI_ACTION_TOKEN`, containing a PAT with repo access.

I didn't test if the script actually works due to the nature of the PR itself. Expect it to not work first time