### PR TITLE
Added the ability to specify `find_file_boundaries` on a per segment basis

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -423,7 +423,9 @@ Same as `symbol_name_format` but for symbols with no rom address
 
 ### find_file_boundaries
 
-Determines whether to detect and hint to the user about likely file splits when disassembling
+Determines whether to detect and hint to the user about likely file splits when disassembling.
+
+This setting can also be set on a per segment basis, if you'd like to enable or disable detection for specific segments. This could be useful when you are confident you identified all subsegments in a segment, yet `splat` still hints that subsegments could be split.  
 
 ### pair_rodata_to_text
 

--- a/segtypes/common/codesubsegment.py
+++ b/segtypes/common/codesubsegment.py
@@ -148,7 +148,7 @@ class CommonSegCodeSubsegment(Segment):
                         self.parent.check_rodata_sym(func_spim.vram, sym)
 
     def print_file_boundaries(self):
-        if not options.opts.find_file_boundaries or not self.spim_section:
+        if not self.show_file_boundaries or not self.spim_section:
             return
 
         assert isinstance(self.rom_start, int)

--- a/segtypes/segment.py
+++ b/segtypes/segment.py
@@ -199,7 +199,7 @@ class Segment:
         self.given_dir: Path = Path()
 
         # Default to global options.
-        self.find_file_boundaries = options.opts.find_file_boundaries
+        self.given_find_file_boundaries: Optional[bool] = None
 
         # Symbols known to be in this segment
         self.given_seg_symbols: Dict[int, List[Symbol]] = {}
@@ -277,9 +277,7 @@ class Segment:
             ret.exclusive_ram_id = yaml.get("exclusive_ram_id")
             ret.given_dir = Path(yaml.get("dir", ""))
             ret.has_linker_entry = bool(yaml.get("linker_entry", True))
-            ret.find_file_boundaries = bool(
-                yaml.get("find_file_boundaries", options.opts.find_file_boundaries)
-            )
+            ret.given_find_file_boundaries = yaml.get("find_file_boundaries", None)
 
         ret.given_symbol_name_format = Segment.parse_segment_symbol_name_format(yaml)
         ret.given_symbol_name_format_no_rom = (
@@ -335,11 +333,15 @@ class Segment:
 
     @property
     def show_file_boundaries(self) -> bool:
-        if self.parent:
-            # If either the parent or the segment itself needs to show boundaries.
-            return self.find_file_boundaries and self.parent.find_file_boundaries
-        else:
-            return self.find_file_boundaries
+        # If the segment has explicitly set `find_file_boundaries`, use it.
+        if self.given_find_file_boundaries is not None:
+            return self.given_find_file_boundaries
+
+        # If the segment has no parent, use options as default.
+        if not self.parent:
+            return options.opts.find_file_boundaries
+
+        return self.parent.show_file_boundaries
 
     @property
     def symbol_name_format(self) -> str:

--- a/segtypes/segment.py
+++ b/segtypes/segment.py
@@ -198,6 +198,9 @@ class Segment:
         self.exclusive_ram_id: Optional[str] = None
         self.given_dir: Path = Path()
 
+        # Default to global options.
+        self.find_file_boundaries = options.opts.find_file_boundaries
+
         # Symbols known to be in this segment
         self.given_seg_symbols: Dict[int, List[Symbol]] = {}
 
@@ -268,11 +271,14 @@ class Segment:
         )
         ret.given_section_order = parse_segment_section_order(yaml)
         ret.given_subalign = parse_segment_subalign(yaml)
+
         if isinstance(yaml, dict):
             ret.extract = bool(yaml.get("extract", ret.extract))
             ret.exclusive_ram_id = yaml.get("exclusive_ram_id")
             ret.given_dir = Path(yaml.get("dir", ""))
             ret.has_linker_entry = bool(yaml.get("linker_entry", True))
+            ret.find_file_boundaries = bool(yaml.get("find_file_boundaries", options.opts.find_file_boundaries))
+
         ret.given_symbol_name_format = Segment.parse_segment_symbol_name_format(yaml)
         ret.given_symbol_name_format_no_rom = (
             Segment.parse_segment_symbol_name_format_no_rom(yaml)
@@ -324,6 +330,14 @@ class Segment:
             return self.parent.dir / self.given_dir
         else:
             return self.given_dir
+
+    @property
+    def show_file_boundaries(self) -> bool:
+        if self.parent:
+            # If either the parent or the segment itself needs to show boundaries.
+            return self.find_file_boundaries and self.parent.find_file_boundaries
+        else:
+            return self.find_file_boundaries
 
     @property
     def symbol_name_format(self) -> str:

--- a/segtypes/segment.py
+++ b/segtypes/segment.py
@@ -277,7 +277,9 @@ class Segment:
             ret.exclusive_ram_id = yaml.get("exclusive_ram_id")
             ret.given_dir = Path(yaml.get("dir", ""))
             ret.has_linker_entry = bool(yaml.get("linker_entry", True))
-            ret.find_file_boundaries = bool(yaml.get("find_file_boundaries", options.opts.find_file_boundaries))
+            ret.find_file_boundaries = bool(
+                yaml.get("find_file_boundaries", options.opts.find_file_boundaries)
+            )
 
         ret.given_symbol_name_format = Segment.parse_segment_symbol_name_format(yaml)
         ret.given_symbol_name_format_no_rom = (


### PR DESCRIPTION
Hi,

Today I wanted to be able to specify `find_file_boundaries` on a per segment basis. The use case for this is so that I can disable the setting on segments that I know are complete, while still retaining the helpful messages it generates for segments that I'm not sure are complete.
