### PR TITLE
Fix rodata errors when using a `cpp` segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # splat Release Notes
 
+### 0.17.3
+
+* Move wiki to the `docs` folder
+* Added the ability to specify `find_file_boundaries` on a per segment basis
+* Fix `cpp` segment not symbolizing rodata symbols properly
+
 ### 0.17.2
+
 * Added more support for PS2 elf files
 
 ### 0.17.1

--- a/segtypes/common/c.py
+++ b/segtypes/common/c.py
@@ -22,17 +22,16 @@ C_FUNC_RE = re.compile(
     r"^(?:static\s+)?[^\s]+\s+([^\s(]+)\(([^;)]*)\)[^;]+?{", re.MULTILINE
 )
 
-C_GLOBAL_ASM_IDO_RE = re.compile(
-    r"GLOBAL_ASM\(\"(\w+\/)*(\w+)\.s\"\)", re.MULTILINE
-)
+C_GLOBAL_ASM_IDO_RE = re.compile(r"GLOBAL_ASM\(\"(\w+\/)*(\w+)\.s\"\)", re.MULTILINE)
+
 
 class CommonSegC(CommonSegCodeSubsegment):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        defined_funcs: Set[str] = set()
-        global_asm_funcs: Set[str] = set()
-        global_asm_rodata_syms: Set[str] = set()
+        self.defined_funcs: Set[str] = set()
+        self.global_asm_funcs: Set[str] = set()
+        self.global_asm_rodata_syms: Set[str] = set()
 
         self.file_extension = "c"
 
@@ -108,9 +107,7 @@ class CommonSegC(CommonSegCodeSubsegment):
         if options.opts.compiler in [GCC, SN64]:
             return set(CommonSegC.find_include_asm(text))
         else:
-            return set(
-                m.group(2) for m in C_GLOBAL_ASM_IDO_RE.finditer(text)
-            )
+            return set(m.group(2) for m in C_GLOBAL_ASM_IDO_RE.finditer(text))
 
     @staticmethod
     def get_global_asm_rodata_syms(c_file: Path) -> Set[str]:
@@ -119,9 +116,7 @@ class CommonSegC(CommonSegCodeSubsegment):
         if options.opts.compiler in [GCC, SN64]:
             return set(CommonSegC.find_include_rodata(text))
         else:
-            return set(
-                m.group(2) for m in C_GLOBAL_ASM_IDO_RE.finditer(text)
-            )
+            return set(m.group(2) for m in C_GLOBAL_ASM_IDO_RE.finditer(text))
 
     @staticmethod
     def is_text() -> bool:

--- a/segtypes/common/code.py
+++ b/segtypes/common/code.py
@@ -9,8 +9,6 @@ from util.symbols import Symbol
 from segtypes.common.group import CommonSegGroup
 from segtypes.segment import Segment, parse_segment_align
 
-CODE_TYPES = ["c", "asm", "hasm"]
-
 
 def dotless_type(type: str) -> str:
     return type[1:] if type[0] == "." else type
@@ -410,10 +408,10 @@ class CommonSegCode(CommonSegGroup):
     def scan(self, rom_bytes):
         # Always scan code first
         for sub in self.subsegments:
-            if sub.type in CODE_TYPES and sub.should_scan():
+            if sub.is_text() and sub.should_scan():
                 sub.scan(rom_bytes)
 
         # Scan everyone else
         for sub in self.subsegments:
-            if sub.type not in CODE_TYPES and sub.should_scan():
+            if not sub.is_text() and sub.should_scan():
                 sub.scan(rom_bytes)

--- a/segtypes/common/cpp.py
+++ b/segtypes/common/cpp.py
@@ -2,4 +2,7 @@ from segtypes.common.c import CommonSegC
 
 
 class CommonSegCpp(CommonSegC):
-    file_extension = "cpp"
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.file_extension = "cpp"

--- a/split.py
+++ b/split.py
@@ -25,7 +25,7 @@ from segtypes.linker_entry import (
 from segtypes.segment import Segment
 from util import log, options, palettes, symbols, relocs
 
-VERSION = "0.17.2"
+VERSION = "0.17.3"
 
 parser = argparse.ArgumentParser(
     description="Split a rom given a rom, a config, and output directory"


### PR DESCRIPTION
Related: #290 

The issue was caused because splat had a list of text segments that should be analyzed before everything else, but the `cpp` segment was not present on that list, so changing from one segment type to the other changed the behavior of the address symbolizer.

I fixed it by not using a hardcoded list.

I also did a few other cleanups on `segtypes/common/c.py` when trying to figure out the problem