### PR TITLE
Fix migrated rdata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### 0.18.2
 
+* Fix rodata migration for `.rdata` sections (and other rodata sections that don't use the name `.rodata`)
+* `spimdisasm` 1.18.0 or above is now required.
+
 ### 0.18.1
 
 * New yaml options: `check_consecutive_segment_types`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # splat Release Notes
 
+### 0.18.2
+
 ### 0.18.1
 
 * New yaml options: `check_consecutive_segment_types`

--- a/disassembler/spimdisasm_disassembler.py
+++ b/disassembler/spimdisasm_disassembler.py
@@ -8,7 +8,7 @@ from typing import Set
 
 class SpimdisasmDisassembler(disassembler.Disassembler):
     # This value should be kept in sync with the version listed on requirements.txt
-    SPIMDISASM_MIN = (1, 17, 0)
+    SPIMDISASM_MIN = (1, 18, 0)
 
     def configure(self, opts: SplatOpts):
         # Configure spimdisasm

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ tqdm
 intervaltree
 colorama
 # This value should be keep in sync with the version listed on disassembler/spimdisasm_disassembler.py
-spimdisasm>=1.17.0
+spimdisasm>=1.18.0
 rabbitizer>=1.7.0
 pygfxd
 n64img>=0.1.4

--- a/segtypes/common/c.py
+++ b/segtypes/common/c.py
@@ -164,7 +164,9 @@ class CommonSegC(CommonSegCodeSubsegment):
                 assert isinstance(
                     self.rodata_sibling, CommonSegRodata
                 ), self.rodata_sibling.type
-                rodata_section_type = self.rodata_sibling.get_linker_section_linksection()
+                rodata_section_type = (
+                    self.rodata_sibling.get_linker_section_linksection()
+                )
                 if self.rodata_sibling.spim_section is not None:
                     assert isinstance(
                         self.rodata_sibling.spim_section.get_section(),

--- a/segtypes/common/c.py
+++ b/segtypes/common/c.py
@@ -155,6 +155,7 @@ class CommonSegC(CommonSegCodeSubsegment):
                 self.spim_section.get_section(), spimdisasm.mips.sections.SectionText
             ), f"{self.name}, rom_start:{self.rom_start}, rom_end:{self.rom_end}"
 
+            rodataSectionType = ""
             rodata_spim_segment: Optional[spimdisasm.mips.sections.SectionRodata] = None
             if (
                 options.opts.migrate_rodata_to_functions
@@ -163,6 +164,7 @@ class CommonSegC(CommonSegCodeSubsegment):
                 assert isinstance(
                     self.rodata_sibling, CommonSegRodata
                 ), self.rodata_sibling.type
+                rodataSectionType = self.rodata_sibling.get_linker_section_linksection()
                 if self.rodata_sibling.spim_section is not None:
                     assert isinstance(
                         self.rodata_sibling.spim_section.get_section(),
@@ -192,6 +194,8 @@ class CommonSegC(CommonSegCodeSubsegment):
 
             # Produce the asm files for functions
             for entry in symbols_entries:
+                entry.sectionText = self.get_linker_section_linksection()
+                entry.sectionRodata = rodataSectionType
                 if entry.function is not None:
                     if (
                         entry.function.getName() in self.global_asm_funcs

--- a/segtypes/common/c.py
+++ b/segtypes/common/c.py
@@ -155,7 +155,7 @@ class CommonSegC(CommonSegCodeSubsegment):
                 self.spim_section.get_section(), spimdisasm.mips.sections.SectionText
             ), f"{self.name}, rom_start:{self.rom_start}, rom_end:{self.rom_end}"
 
-            rodataSectionType = ""
+            rodata_section_type = ""
             rodata_spim_segment: Optional[spimdisasm.mips.sections.SectionRodata] = None
             if (
                 options.opts.migrate_rodata_to_functions
@@ -164,7 +164,7 @@ class CommonSegC(CommonSegCodeSubsegment):
                 assert isinstance(
                     self.rodata_sibling, CommonSegRodata
                 ), self.rodata_sibling.type
-                rodataSectionType = self.rodata_sibling.get_linker_section_linksection()
+                rodata_section_type = self.rodata_sibling.get_linker_section_linksection()
                 if self.rodata_sibling.spim_section is not None:
                     assert isinstance(
                         self.rodata_sibling.spim_section.get_section(),
@@ -195,7 +195,7 @@ class CommonSegC(CommonSegCodeSubsegment):
             # Produce the asm files for functions
             for entry in symbols_entries:
                 entry.sectionText = self.get_linker_section_linksection()
-                entry.sectionRodata = rodataSectionType
+                entry.sectionRodata = rodata_section_type
                 if entry.function is not None:
                     if (
                         entry.function.getName() in self.global_asm_funcs

--- a/split.py
+++ b/split.py
@@ -25,7 +25,7 @@ from segtypes.linker_entry import (
 from segtypes.segment import Segment
 from util import log, options, palettes, symbols, relocs
 
-VERSION = "0.18.1"
+VERSION = "0.18.2"
 
 parser = argparse.ArgumentParser(
     description="Split a rom given a rom, a config, and output directory"


### PR DESCRIPTION
Migrating `.rdata` (not `.rodata`) was broken due to `spimdisasm` hardcoding the section of the migrated symbols instead of allowing to customize it