### PR TITLE
ld_fill_value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # splat Release Notes
 
+### 0.18.3
+
+* splat now will emit a `FILL(0)` statement on each segment of a linker script by default, to customize this behavior use the `ld_fill_value` yaml option or the per-segment `ld_fill_value` option.
+* New yaml option: `ld_fill_value`
+  * Allows to specify the value of the `FILL` statement generated on every segment of the linker script.
+  * It must be either an integer, which will be used as the parameter for the `FILL` statement, or `null`, which tells splat to not emit `FILL` statements.
+  * This behavior can be customized per segment too.
+* New per segment option: `ld_fill_value`
+  * Allows to specify the value of the `FILL` statement generated for this specific top-level segment of the linker script, ignoring the global configuration.
+  * If not set, then the global configuration is used.
+
 ### 0.18.2
 
 * Fix rodata migration for `.rdata` sections (and other rodata sections that don't use the name `.rodata`)

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -405,6 +405,17 @@ Possible values:
 Specifies the starting offset for rom address symbols in the linker script.
 
 
+### ld_fill_value
+
+Allows to specify the value of the `FILL` statement generated on every segment of the linker script.
+
+It must be either an integer, which will be used as the parameter for the `FILL` statement, or `null`, which tells splat to not emit `FILL` statements.
+
+This behavior can be customized per segment too. See [ld_fill_value](Segments.md#ld_fill_value) on the Segments section.
+
+Defaults to 0.
+
+
 ## C file options
 
 ### create_c_files

--- a/docs/Segments.md
+++ b/docs/Segments.md
@@ -300,3 +300,13 @@ Useful for sections with special names, like an executable section named `.start
 - [0x1070, rdata, libc]
 - [0x10A0, rdata, main_030]
 ```
+
+### `ld_fill_value`
+
+Allows to specify the value of the `FILL` statement generated for this specific top-level segment of the linker script, ignoring the global configuration.
+
+It must be either an integer, which will be used as the parameter for the `FILL` statement, or `null`, which tells splat to not emit a `FILL` statement for this segment.
+
+If not set, then the global configuration is used. See [ld_fill_value](Configuration.md#ld_fill_value) on the Configuration section.
+
+Defaults to the value of the global option.

--- a/segtypes/linker_entry.py
+++ b/segtypes/linker_entry.py
@@ -541,6 +541,9 @@ class LinkerWriter:
         self._writeln(line)
         self._begin_block()
 
+        if segment.ld_fill_value is not None:
+            self._writeln(f"FILL(0x{segment.ld_fill_value:08X});")
+
     def _end_segment(self, segment: Segment, all_bss=False):
         self._end_block()
 

--- a/segtypes/segment.py
+++ b/segtypes/segment.py
@@ -190,7 +190,9 @@ class Segment:
         return None
 
     @staticmethod
-    def parse_ld_fill_value(yaml: Union[dict, list], default: Optional[int]) -> Optional[int]:
+    def parse_ld_fill_value(
+        yaml: Union[dict, list], default: Optional[int]
+    ) -> Optional[int]:
         if isinstance(yaml, dict) and "ld_fill_value" in yaml:
             return yaml["ld_fill_value"]
         return default
@@ -262,7 +264,9 @@ class Segment:
         self.linker_section: Optional[str] = self.parse_linker_section(yaml)
 
         # If not defined on the segment then default to the global option
-        self.ld_fill_value: Optional[int] = self.parse_ld_fill_value(yaml, options.opts.ld_fill_value)
+        self.ld_fill_value: Optional[int] = self.parse_ld_fill_value(
+            yaml, options.opts.ld_fill_value
+        )
 
         if self.rom_start is not None and self.rom_end is not None:
             if self.rom_start > self.rom_end:

--- a/segtypes/segment.py
+++ b/segtypes/segment.py
@@ -189,6 +189,12 @@ class Segment:
             return str(yaml["linker_section"])
         return None
 
+    @staticmethod
+    def parse_ld_fill_value(yaml: Union[dict, list], default: Optional[int]) -> Optional[int]:
+        if isinstance(yaml, dict) and "ld_fill_value" in yaml:
+            return yaml["ld_fill_value"]
+        return default
+
     def __init__(
         self,
         rom_start: Optional[int],
@@ -254,6 +260,9 @@ class Segment:
 
         self.linker_section_order: Optional[str] = self.parse_linker_section_order(yaml)
         self.linker_section: Optional[str] = self.parse_linker_section(yaml)
+
+        # If not defined on the segment then default to the global option
+        self.ld_fill_value: Optional[int] = self.parse_ld_fill_value(yaml, options.opts.ld_fill_value)
 
         if self.rom_start is not None and self.rom_end is not None:
             if self.rom_start > self.rom_end:

--- a/split.py
+++ b/split.py
@@ -25,7 +25,7 @@ from segtypes.linker_entry import (
 from segtypes.segment import Segment
 from util import log, options, palettes, symbols, relocs
 
-VERSION = "0.18.2"
+VERSION = "0.18.3"
 
 parser = argparse.ArgumentParser(
     description="Split a rom given a rom, a config, and output directory"

--- a/test/basic_app/expected/basic_app.ld
+++ b/test/basic_app/expected/basic_app.ld
@@ -6,6 +6,7 @@ SECTIONS
     header_VRAM = ADDR(.header);
     .header : AT(header_ROM_START) SUBALIGN(16)
     {
+        FILL(0x00000000);
         header_DATA_START = .;
         header_s = .;
         build/split/asm/header.s.o(.data);
@@ -20,6 +21,7 @@ SECTIONS
     dummy_ipl3_VRAM = ADDR(.dummy_ipl3);
     .dummy_ipl3 0xA4000040 : AT(dummy_ipl3_ROM_START) SUBALIGN(16)
     {
+        FILL(0x00000000);
         dummy_ipl3_DATA_START = .;
         dummy_ipl3_bin = .;
         build/split/assets/dummy_ipl3.bin.o(.data);
@@ -35,6 +37,7 @@ SECTIONS
     boot_VRAM = ADDR(.boot);
     .boot 0x80000400 : AT(boot_ROM_START) SUBALIGN(16)
     {
+        FILL(0x00000000);
         boot_TEXT_START = .;
         build/split/src/main.c.o(.text);
         build/split/asm/handwritten.s.o(.text);
@@ -53,6 +56,7 @@ SECTIONS
     boot_bss_VRAM = ADDR(.boot_bss);
     .boot_bss (NOLOAD) : SUBALIGN(16)
     {
+        FILL(0x00000000);
         boot_BSS_START = .;
         build/split/asm/data/main.bss.s.o(.bss);
         boot_BSS_END = .;

--- a/util/options.py
+++ b/util/options.py
@@ -126,6 +126,8 @@ class SplatOpts:
     segment_symbols_style: str
     # Specifies the starting offset for rom address symbols in the linker script.
     ld_rom_start: int
+    # The value passed to the FILL statement on each segment. `None` disables using FILL statements on the linker script. Defaults to a fill value of 0.
+    ld_fill_value: Optional[int]
 
     ################################################################################
     # C file options
@@ -418,6 +420,7 @@ def _parse_yaml(
             "segment_symbols_style", str, ["splat", "makerom"], "splat"
         ),
         ld_rom_start=p.parse_opt("ld_rom_start", int, 0),
+        ld_fill_value=p.parse_opt("ld_fill_value", int, 0),
         create_c_files=p.parse_opt("create_c_files", bool, True),
         auto_decompile_empty_functions=p.parse_opt(
             "auto_decompile_empty_functions", bool, True


### PR DESCRIPTION
Due to Wiseguy and my investigation on trying to use `lld` (clang's linker) on decomp projects, we discovered `lld` pads executable sections with trap instructions instead of zeroes. The simplest way we found to avoid this behavior was to put a `FILL` statement on each segment on the linker script to force linkers to fill pads with zeroes.

So I went ahead and implemented `FILL` on splat. splat will start emitting `FILL(0)` statements on every segment on the linker script by default. To make it a bit more flexible I also implemented options to choose which value the linker will use as the filler, disable the `FILL`s completely and change the behavior for specific segments.