### PR TITLE
`ld_bss_is_noload`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # splat Release Notes
 
+### 0.18.4
+
+* New yaml option: `ld_bss_is_noload`
+  * Allows to control if `bss` sections (and derivatived sections) will be put on a `NOLOAD` segment on the generated linker script or not.
+  * Applies to all `bss` (`sbss`, `common`, `scommon`, etc) sections.
+  * Defaults to `True`, meaning `bss` sections will be put on `NOLOAD` segments.
+
 ### 0.18.3
 
 * splat now will emit a `FILL(0)` statement on each segment of a linker script by default, to customize this behavior use the `ld_fill_value` yaml option or the per-segment `ld_fill_value` option.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -416,6 +416,15 @@ This behavior can be customized per segment too. See [ld_fill_value](Segments.md
 Defaults to 0.
 
 
+### ld_bss_is_noload
+
+Allows to control if `bss` sections (and derivatived sections) will be put on a `NOLOAD` segment on the generated linker script or not.
+
+Applies to all `bss` (`sbss`, `common`, `scommon`, etc) sections.
+
+Defaults to `True`, meaning `bss` sections will be put on `NOLOAD` segments.
+
+
 ## C file options
 
 ### create_c_files

--- a/segtypes/common/bss.py
+++ b/segtypes/common/bss.py
@@ -11,6 +11,8 @@ class CommonSegBss(CommonSegData):
 
     @staticmethod
     def is_noload() -> bool:
+        if not options.opts.ld_bss_is_noload:
+            return False
         return True
 
     def disassemble_data(self, rom_bytes: bytes):

--- a/split.py
+++ b/split.py
@@ -25,7 +25,7 @@ from segtypes.linker_entry import (
 from segtypes.segment import Segment
 from util import log, options, palettes, symbols, relocs
 
-VERSION = "0.18.3"
+VERSION = "0.18.4"
 
 parser = argparse.ArgumentParser(
     description="Split a rom given a rom, a config, and output directory"

--- a/util/options.py
+++ b/util/options.py
@@ -128,6 +128,8 @@ class SplatOpts:
     ld_rom_start: int
     # The value passed to the FILL statement on each segment. `None` disables using FILL statements on the linker script. Defaults to a fill value of 0.
     ld_fill_value: Optional[int]
+    # 
+    ld_bss_is_noload: bool
 
     ################################################################################
     # C file options
@@ -421,6 +423,7 @@ def _parse_yaml(
         ),
         ld_rom_start=p.parse_opt("ld_rom_start", int, 0),
         ld_fill_value=p.parse_opt("ld_fill_value", int, 0),
+        ld_bss_is_noload=p.parse_opt("ld_bss_is_noload", bool, True),
         create_c_files=p.parse_opt("create_c_files", bool, True),
         auto_decompile_empty_functions=p.parse_opt(
             "auto_decompile_empty_functions", bool, True

--- a/util/options.py
+++ b/util/options.py
@@ -128,7 +128,7 @@ class SplatOpts:
     ld_rom_start: int
     # The value passed to the FILL statement on each segment. `None` disables using FILL statements on the linker script. Defaults to a fill value of 0.
     ld_fill_value: Optional[int]
-    # 
+    # Allows to control if `bss` sections (and derivatived sections) will be put on a `NOLOAD` segment on the generated linker script or not.
     ld_bss_is_noload: bool
 
     ################################################################################


### PR DESCRIPTION
Allows to control if `bss` sections (and derivatived sections) will be put on a `NOLOAD` segment on the generated linker script or not.

Applies to all `bss` (`sbss`, `common`, `scommon`, etc) sections.

Defaults to `True`, meaning `bss` sections will be put on `NOLOAD` segments.
