### PR TITLE
Fix `bss_contains_common` not being passed to auto all segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # splat Release Notes
 
+### 0.21.6
+
+* Fix `bss_contains_common` option not being passed to "auto all" inserted sections
+
 ### 0.21.5
 
 * Fixed issue with Python 3.8 compatibility (oops)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### 0.21.6
 
-* Fix `bss_contains_common` option not being passed to "auto all" inserted sections
+* Fix `bss_contains_common` option not being passed to "auto all" inserted sections.
+* New yaml option: `ld_bss_contains_common`
+  * Sets the default option for the `bss_contains_common` attribute of all segments.
 
 ### 0.21.5
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The brackets corresponds to the optional dependencies to install while installin
 If you use a `requirements.txt` file in your repository, then you can add this library with the following line:
 
 ```txt
-splat64[mips]>=0.21.2,<1.0.0
+splat64[mips]>=0.21.6,<1.0.0
 ```
 
 ### Optional dependencies

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -462,6 +462,12 @@ If enabled, the generated linker script will have a linker symbol for each data 
 
 Defaults to `True`.
 
+### ld_bss_contains_common
+
+Sets the default option for the `bss_contains_common` attribute of all segments.
+
+Defaults to `False`.
+
 ## C file options
 
 ### create_c_files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.21.5"
+version = "0.21.6"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -3,7 +3,7 @@ from typing import Tuple
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version_info__: Tuple[int, int, int] = (0, 21, 5)
+__version_info__: Tuple[int, int, int] = (0, 21, 6)
 __version__ = ".".join(map(str, __version_info__))
 __author__ = "ethteck"
 

--- a/src/splat/segtypes/common/code.py
+++ b/src/splat/segtypes/common/code.py
@@ -83,6 +83,7 @@ class CommonSegCode(CommonSegGroup):
         rep.is_auto_all = True
         if rep.special_vram_segment:
             self.special_vram_segment = True
+        rep.bss_contains_common = self.bss_contains_common
         return rep
 
     def _insert_all_auto_sections(

--- a/src/splat/segtypes/segment.py
+++ b/src/splat/segtypes/segment.py
@@ -187,7 +187,9 @@ class Segment:
         return None
 
     @staticmethod
-    def parse_segment_bss_contains_common(segment: Union[dict, list], default: bool) -> bool:
+    def parse_segment_bss_contains_common(
+        segment: Union[dict, list], default: bool
+    ) -> bool:
         if isinstance(segment, dict) and "bss_contains_common" in segment:
             return bool(segment["bss_contains_common"])
         return default
@@ -271,7 +273,9 @@ class Segment:
 
         self.warnings: List[str] = []
         self.did_run = False
-        self.bss_contains_common = Segment.parse_segment_bss_contains_common(yaml, options.opts.ld_bss_contains_common)
+        self.bss_contains_common = Segment.parse_segment_bss_contains_common(
+            yaml, options.opts.ld_bss_contains_common
+        )
 
         # For segments which are not in the usual VRAM segment space, like N64's IPL3 which lives in 0xA4...
         self.special_vram_segment: bool = False
@@ -340,7 +344,9 @@ class Segment:
         )
         ret.file_path = Segment.parse_segment_file_path(yaml)
 
-        ret.bss_contains_common = Segment.parse_segment_bss_contains_common(yaml, options.opts.ld_bss_contains_common)
+        ret.bss_contains_common = Segment.parse_segment_bss_contains_common(
+            yaml, options.opts.ld_bss_contains_common
+        )
 
         ret.given_follows_vram = parse_segment_follows_vram(yaml)
         ret.given_vram_symbol = parse_segment_vram_symbol(yaml)

--- a/src/splat/segtypes/segment.py
+++ b/src/splat/segtypes/segment.py
@@ -187,11 +187,10 @@ class Segment:
         return None
 
     @staticmethod
-    def parse_segment_bss_contains_common(segment: Union[dict, list]) -> bool:
+    def parse_segment_bss_contains_common(segment: Union[dict, list], default: bool) -> bool:
         if isinstance(segment, dict) and "bss_contains_common" in segment:
             return bool(segment["bss_contains_common"])
-        else:
-            return False
+        return default
 
     @staticmethod
     def parse_linker_section_order(yaml: Union[dict, list]) -> Optional[str]:
@@ -272,7 +271,7 @@ class Segment:
 
         self.warnings: List[str] = []
         self.did_run = False
-        self.bss_contains_common = Segment.parse_segment_bss_contains_common(yaml)
+        self.bss_contains_common = Segment.parse_segment_bss_contains_common(yaml, options.opts.ld_bss_contains_common)
 
         # For segments which are not in the usual VRAM segment space, like N64's IPL3 which lives in 0xA4...
         self.special_vram_segment: bool = False
@@ -341,7 +340,7 @@ class Segment:
         )
         ret.file_path = Segment.parse_segment_file_path(yaml)
 
-        ret.bss_contains_common = Segment.parse_segment_bss_contains_common(yaml)
+        ret.bss_contains_common = Segment.parse_segment_bss_contains_common(yaml, options.opts.ld_bss_contains_common)
 
         ret.given_follows_vram = parse_segment_follows_vram(yaml)
         ret.given_vram_symbol = parse_segment_vram_symbol(yaml)

--- a/src/splat/util/options.py
+++ b/src/splat/util/options.py
@@ -139,6 +139,8 @@ class SplatOpts:
     ld_align_section_vram_end: bool
     # If enabled, the generated linker script will have a linker symbol for each data file
     ld_generate_symbol_per_data_segment: bool
+    # Sets the default option for the `bss_contains_common` attribute of all segments.
+    ld_bss_contains_common: bool
 
     ################################################################################
     # C file options
@@ -456,6 +458,7 @@ def _parse_yaml(
         ld_generate_symbol_per_data_segment=p.parse_opt(
             "ld_generate_symbol_per_data_segment", bool, True
         ),
+        ld_bss_contains_common=p.parse_opt("ld_bss_contains_common", bool, False),
         create_c_files=p.parse_opt("create_c_files", bool, True),
         auto_decompile_empty_functions=p.parse_opt(
             "auto_decompile_empty_functions", bool, True


### PR DESCRIPTION
Also added a global option `ld_bss_contains_common`, because setting `bss_contains_common: True` on every segment is kinda annoying