### PR TITLE
`allow_duplicated` attribute for symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # splat Release Notes
 
+### 0.21.7
+
+* New attribute for symbols: `allow_duplicated`
+  * Allows to lift the duplicated symbol restriction for the specified symbols, allowing to have specific symbols that are not checked for shared vrams or names but keeping the check for everything else.
+
 ### 0.21.6
 
 * Fix `bss_contains_common` option not being passed to "auto all" inserted sections.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The brackets corresponds to the optional dependencies to install while installin
 If you use a `requirements.txt` file in your repository, then you can add this library with the following line:
 
 ```txt
-splat64[mips]>=0.21.6,<1.0.0
+splat64[mips]>=0.21.7,<1.0.0
 ```
 
 ### Optional dependencies

--- a/docs/Adding-Symbols.md
+++ b/docs/Adding-Symbols.md
@@ -141,6 +141,8 @@ Tells splat that a symbol is allowed to have its vram/name duplicated with anoth
 
 This attribute has to be specified on all symbols that share the same vram or name.
 
+**Warning**: Take in mind that using this feature for assembly symbols may produce errors on the build, like duplicated symbol errors on the linker. Use with caution.
+
 **Example**
 ```ini
 obj_fallCA1_tex_rgb_ia8 = 0x06013118; // allow_duplicated:True

--- a/docs/Adding-Symbols.md
+++ b/docs/Adding-Symbols.md
@@ -134,3 +134,16 @@ This attribute overrides the global `allow_data_addends` option.
 ```ini
 aspMainTextStart = 0x80084760; // dont_allow_addend:True
 ```
+
+### `allow_duplicated`
+
+Tells splat that a symbol is allowed to have its vram/name duplicated with another symbol.
+
+This attribute has to be specified on all symbols that share the same vram or name.
+
+**Example**
+```ini
+obj_fallCA1_tex_rgb_ia8 = 0x06013118; // allow_duplicated:True
+// ...
+obj_fallCA1_tex_rgb_ia8 = 0x060140A8; // allow_duplicated:True
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.21.6"
+version = "0.21.7"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/splat/segtypes/common/code.py
+++ b/src/splat/segtypes/common/code.py
@@ -204,12 +204,12 @@ class CommonSegCode(CommonSegGroup):
 
             if segment.sibling is not None:
                 # Make siblings reference between them
-                segment.siblings[
-                    segment.sibling.get_linker_section_linksection()
-                ] = segment.sibling
-                segment.sibling.siblings[
-                    segment.get_linker_section_linksection()
-                ] = segment
+                segment.siblings[segment.sibling.get_linker_section_linksection()] = (
+                    segment.sibling
+                )
+                segment.sibling.siblings[segment.get_linker_section_linksection()] = (
+                    segment
+                )
 
             segment.parent = self
             if segment.special_vram_segment:

--- a/src/splat/util/options.py
+++ b/src/splat/util/options.py
@@ -533,9 +533,9 @@ def _parse_yaml(
             "detect_redundant_function_end", bool, True
         ),
         # Command line argument takes precedence over yaml option
-        disassemble_all=disasm_all
-        if disasm_all
-        else p.parse_opt("disassemble_all", bool, False),
+        disassemble_all=(
+            disasm_all if disasm_all else p.parse_opt("disassemble_all", bool, False)
+        ),
     )
     p.check_no_unread_opts()
     return ret

--- a/src/splat/util/symbols.py
+++ b/src/splat/util/symbols.py
@@ -193,9 +193,7 @@ def handle_sym_addrs(
                         tf_val = (
                             True
                             if is_truey(attr_val)
-                            else False
-                            if is_falsey(attr_val)
-                            else None
+                            else False if is_falsey(attr_val) else None
                         )
                         if tf_val is None:
                             log.parsing_error_preamble(path, line_num, line)
@@ -249,10 +247,11 @@ def handle_sym_addrs(
             sym.user_declared = True
 
             if sym.name in seen_symbols:
-                if not sym.allow_duplicated or not seen_symbols[sym.name].allow_duplicated:
+                item = seen_symbols[sym.name]
+                if not sym.allow_duplicated or not item.allow_duplicated:
                     log.parsing_error_preamble(path, line_num, line)
                     log.error(
-                        f"Duplicate symbol detected! {sym.name} has already been defined at vram 0x{seen_symbols[sym.name].vram_start:08X}"
+                        f"Duplicate symbol detected! {sym.name} has already been defined at vram 0x{item.vram_start:08X}"
                     )
 
             if addr in all_symbols_dict:

--- a/src/splat/util/symbols.py
+++ b/src/splat/util/symbols.py
@@ -252,7 +252,7 @@ def handle_sym_addrs(
                 if not sym.allow_duplicated or not seen_symbols[sym.name].allow_duplicated:
                     log.parsing_error_preamble(path, line_num, line)
                     log.error(
-                        f"Duplicate symbol detected! {sym.name} has already been defined at vram 0x{seen_symbols[sym.name].vram_start:X}"
+                        f"Duplicate symbol detected! {sym.name} has already been defined at vram 0x{seen_symbols[sym.name].vram_start:08X}"
                     )
 
             if addr in all_symbols_dict:
@@ -265,7 +265,7 @@ def handle_sym_addrs(
                         if not sym.allow_duplicated or not item.allow_duplicated:
                             log.parsing_error_preamble(path, line_num, line)
                             log.error(
-                                f"Duplicate symbol detected! {sym.name} clashes with {item.name} defined at vram 0x{addr:X}.\n  If this is intended, specify either a segment or a rom address for this symbol"
+                                f"Duplicate symbol detected! {sym.name} clashes with {item.name} defined at vram 0x{addr:08X}.\n  If this is intended, specify either a segment or a rom address for this symbol"
                             )
 
             seen_symbols[sym.name] = sym
@@ -370,13 +370,13 @@ def initialize_spim_context(all_segments: "List[Segment]") -> None:
         for ovl_segment in overlay_segments:
             assert (
                 ovl_segment.vramStart <= ovl_segment.vramEnd
-            ), f"{ovl_segment.vramStart:X} {ovl_segment.vramEnd:X}"
+            ), f"{ovl_segment.vramStart:08X} {ovl_segment.vramEnd:08X}"
             if (
                 ovl_segment.vramEnd > global_vram_start
                 and global_vram_end > ovl_segment.vramStart
             ):
                 log.write(
-                    f"Warning: the vram range ([0x{ovl_segment.vramStart:X}, 0x{ovl_segment.vramEnd:X}]) of the non-global segment at rom address 0x{ovl_segment.vromStart:X} overlaps with the global vram range ([0x{global_vram_start:X}, 0x{global_vram_end:X}])",
+                    f"Warning: the vram range ([0x{ovl_segment.vramStart:08X}, 0x{ovl_segment.vramEnd:08X}]) of the non-global segment at rom address 0x{ovl_segment.vromStart:X} overlaps with the global vram range ([0x{global_vram_start:08X}, 0x{global_vram_end:08X}])",
                     status="warn",
                 )
 
@@ -600,7 +600,7 @@ class Symbol:
         if "$ROM" in ret:
             if not isinstance(self.rom, int):
                 log.error(
-                    f"Attempting to rom-name a symbol with no ROM address: {self.vram_start:X} typed {self.type}"
+                    f"Attempting to rom-name a symbol with no ROM address: {self.vram_start:08X} typed {self.type}"
                 )
             ret = ret.replace("$ROM", f"{self.rom:X}")
 


### PR DESCRIPTION
Allows to specify specific symbols to not be checked if they have a duplicated name or vram address on the symbol_addrs file.

This way people can use duplicated names without turning off the whole duplicated checker.

This is required by af, which uses original symbols, and there are a few static ones that are duplicated, but we need splat to know their names for asset extraction.