### PR TITLE
Allow the global `subalign` option to accept `null`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # splat Release Notes
 
+### 0.21.10
+
+* Allow the global `subalign` option to take `null` values
+
 ### 0.21.9
 
 * Removed gc code in favor of decomp-toolkit, which is now linked-to from this project.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The brackets corresponds to the optional dependencies to install while installin
 If you use a `requirements.txt` file in your repository, then you can add this library with the following line:
 
 ```txt
-splat64[mips]>=0.21.9,<1.0.0
+splat64[mips]>=0.21.10,<1.0.0
 ```
 
 ### Optional dependencies

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -326,6 +326,8 @@ elf_section_list_path: path/to/elf_sections
 
 Sub-alignment (in bytes) of sections.
 
+`subalign` can be `null` to not force any specific alignment and use the built section's declared alignment instead.
+
 #### Usage
 ```yaml
 subalign: 4

--- a/docs/Segments.md
+++ b/docs/Segments.md
@@ -324,3 +324,19 @@ It must be either an integer, which will be used as the parameter for the `FILL`
 If not set, then the global configuration is used. See [ld_fill_value](Configuration.md#ld_fill_value) on the Configuration section.
 
 Defaults to the value of the global option.
+
+### `subalign`
+
+Sub-alignment (in bytes) of sections.
+
+Only works on top-level segments
+
+`subalign` can be `null` to not force any specific alignment and use the built section's declared alignment instead.
+
+**Example:**
+
+```yaml
+    subalign: 4
+```
+
+Defaults to the global `subalign` option.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.21.9"
+version = "0.21.10"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -3,7 +3,7 @@ from typing import Tuple
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version_info__: Tuple[int, int, int] = (0, 21, 9)
+__version_info__: Tuple[int, int, int] = (0, 21, 10)
 __version__ = ".".join(map(str, __version_info__))
 __author__ = "ethteck"
 

--- a/src/splat/segtypes/segment.py
+++ b/src/splat/segtypes/segment.py
@@ -55,7 +55,7 @@ def parse_segment_subalign(segment: Union[dict, list]) -> Optional[int]:
     if isinstance(segment, dict):
         subalign = segment.get("subalign", default)
         if subalign != None:
-            subalign = int(subalign, 0)
+            subalign = int(subalign)
         return subalign
     return default
 

--- a/src/splat/segtypes/segment.py
+++ b/src/splat/segtypes/segment.py
@@ -50,12 +50,12 @@ def parse_segment_align(segment: Union[dict, list]) -> Optional[int]:
     return None
 
 
-def parse_segment_subalign(segment: Union[dict, list]) -> int:
+def parse_segment_subalign(segment: Union[dict, list]) -> Optional[int]:
     default = options.opts.subalign
     if isinstance(segment, dict):
         subalign = segment.get("subalign", default)
         if subalign != None:
-            subalign = int(subalign)
+            subalign = int(subalign, 0)
         return subalign
     return default
 
@@ -231,7 +231,7 @@ class Segment:
         self.vram_start: Optional[int] = vram_start
 
         self.align: Optional[int] = None
-        self.given_subalign: int = options.opts.subalign
+        self.given_subalign: Optional[int] = options.opts.subalign
         self.exclusive_ram_id: Optional[str] = None
         self.given_dir: Path = Path()
 
@@ -422,7 +422,7 @@ class Segment:
         return self.given_symbol_name_format_no_rom
 
     @property
-    def subalign(self) -> int:
+    def subalign(self) -> Optional[int]:
         if self.parent:
             return self.parent.subalign
         else:

--- a/src/splat/util/options.py
+++ b/src/splat/util/options.py
@@ -89,7 +89,7 @@ class SplatOpts:
 
     # Linker script
     # Determines the default subalign value to be specified in the generated linker script
-    subalign: int
+    subalign: Optional[int]
     # The following option determines whether to automatically configure the linker script to link against
     # specified sections for all "base" (asm/c) files when the yaml doesn't have manual configurations
     # for these sections.
@@ -413,7 +413,7 @@ def _parse_yaml(
         extensions_path=p.parse_optional_path(base_path, "extensions_path"),
         lib_path=p.parse_path(base_path, "lib_path", "lib"),
         elf_section_list_path=p.parse_optional_path(base_path, "elf_section_list_path"),
-        subalign=p.parse_opt("subalign", int, 16),
+        subalign=p.parse_optional_opt_with_default("subalign", int, 16),
         auto_all_sections=p.parse_opt(
             "auto_all_sections", list, [".data", ".rodata", ".bss"]
         ),


### PR DESCRIPTION
Per segment `subalign` already accepts `null`, so it makes sense for this one to accept it too