### PR TITLE
Allow lib segment to use dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### 0.21.11
 
 * Show an error on `create_config` if the format is not supported.
+* Allow lib segment to be a dictionary with `object` and `section` options
+* Allow lib segment to use `vram` option
 
 ### 0.21.10
 

--- a/src/splat/segtypes/common/lib.py
+++ b/src/splat/segtypes/common/lib.py
@@ -50,18 +50,21 @@ class CommonSegLib(CommonSegment):
         )
 
         if isinstance(yaml, dict):
-            log.error("Error: 'dict' not currently supported for 'lib' segment")
-            return
-        if len(args) < 1:
-            log.error(f"Error: {self.name} is missing object file")
-            return
+            self.object = yaml.get('object', None)
+            self.section = yaml.get('section', '.text')
+
+            if self.object is None:
+                log.error(f"Error: {self.name} is missing object file")
+        else:
+            if len(args) < 1:
+                log.error(f"Error: {self.name} is missing object file")
+
+            if len(args) > 1:
+                self.object, self.section = args[0], args[1]
+            else:
+                self.object, self.section = args[0], ".text"
 
         self.extract = False
-
-        if len(args) > 1:
-            self.object, self.section = args[0], args[1]
-        else:
-            self.object, self.section = args[0], ".text"
 
     def get_linker_section(self) -> str:
         return self.section

--- a/src/splat/segtypes/common/lib.py
+++ b/src/splat/segtypes/common/lib.py
@@ -6,7 +6,7 @@ from ...util import log, options
 from ..linker_entry import LinkerEntry, LinkerWriter
 from .segment import CommonSegment
 
-from ..segment import Segment
+from ..segment import Segment, parse_segment_vram
 
 
 class LinkerEntryLib(LinkerEntry):
@@ -48,6 +48,10 @@ class CommonSegLib(CommonSegment):
             args=args,
             yaml=yaml,
         )
+
+        vram = parse_segment_vram(self.yaml)
+        if vram is not None:
+            self.vram_start = vram
 
         if isinstance(yaml, dict):
             self.object = yaml.get('object', None)

--- a/src/splat/segtypes/common/lib.py
+++ b/src/splat/segtypes/common/lib.py
@@ -54,8 +54,8 @@ class CommonSegLib(CommonSegment):
             self.vram_start = vram
 
         if isinstance(yaml, dict):
-            self.object = yaml.get('object', None)
-            self.section = yaml.get('section', '.text')
+            self.object = yaml.get("object", None)
+            self.section = yaml.get("section", ".text")
 
             if self.object is None:
                 log.error(f"Error: {self.name} is missing object file")


### PR DESCRIPTION
This allows the lib segment to be used as a dictionary.

The following options are allowed:
* object: The name of the object file to link from the archive
* section: The section of the object file to link from the archive
* vram: Allows to specify the vram (important for linking bss from an archive)

Note: I'm wondering if instead of allowing to specify the section we should instead have different segments all together like `bin`? (e.g. `textlib`, `datalib`, `rodatalib`, `bsslib`)

Note 2: I uped the version number and added to changelog, but this no means needs a release yet. We could add to it further. Not sure if you would prefer this PR to some kind of dev branch instead?