### PR TITLE
`create_config`: Error on unrecognized input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # splat Release Notes
 
+### 0.21.11
+
+* Show an error on `create_config` if the format is not supported.
+
 ### 0.21.10
 
 * Allow the global `subalign` option to take `null` values

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The brackets corresponds to the optional dependencies to install while installin
 If you use a `requirements.txt` file in your repository, then you can add this library with the following line:
 
 ```txt
-splat64[mips]>=0.21.10,<1.0.0
+splat64[mips]>=0.21.11,<1.0.0
 ```
 
 ### Optional dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.21.10"
+version = "0.21.11"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -3,7 +3,7 @@ from typing import Tuple
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version_info__: Tuple[int, int, int] = (0, 21, 10)
+__version_info__: Tuple[int, int, int] = (0, 21, 11)
 __version__ = ".".join(map(str, __version_info__))
 __author__ = "ethteck"
 

--- a/src/splat/scripts/create_config.py
+++ b/src/splat/scripts/create_config.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from ..util.n64 import find_code_length, rominfo
 from ..util.psx import psxexeinfo
+from ..util import log
 
 
 def main(file_path: Path):
@@ -25,6 +26,8 @@ def main(file_path: Path):
     if file_bytes[0:8] == b"PS-X EXE":
         create_psx_config(file_path, file_bytes)
         return
+
+    log.error(f"create_config does not support the file format of '{file_path}'")
 
 
 def create_n64_config(rom_path: Path):


### PR DESCRIPTION
Output an error if the file passed to `create_config` is not recognized.

Currently the script prints thing at all, which is confusing for the user.

Inspired by #341 