### PR TITLE
autosegments insertion fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # splat Release Notes
 
+### 0.23.2
+
+* Fixed a bug where auto segments insertion may not respect the proper ordering if there are linker_offset segments present.
+
 ### 0.23.1
 
 * New `EEGCC` compiler option.
@@ -37,7 +41,6 @@
 ### 0.22.2
 
 * Allow for `image_type_in_extension` to be overridden by subclasses of N64SegImg
-* Fixed a bug where auto segments insertion may not respect the proper ordering if there are linker_offset segments present.
 
 ### 0.22.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # splat Release Notes
 
+### 0.22.2
+
+* Fixed a bug where auto segments insertion may not respect the proper ordering if there are linker_offset segments present.
+
 ### 0.22.1
 
 * Fixed a bug where palettes with `global_id`s were reporing errors too eagerly

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The brackets corresponds to the optional dependencies to install while installin
 If you use a `requirements.txt` file in your repository, then you can add this library with the following line:
 
 ```txt
-splat64[mips]>=0.23.1,<1.0.0
+splat64[mips]>=0.23.2,<1.0.0
 ```
 
 ### Optional dependencies

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The brackets corresponds to the optional dependencies to install while installin
 If you use a `requirements.txt` file in your repository, then you can add this library with the following line:
 
 ```txt
-splat64[mips]>=0.22.1,<1.0.0
+splat64[mips]>=0.22.2,<1.0.0
 ```
 
 ### Optional dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.22.1"
+version = "0.22.2"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.23.1"
+version = "0.23.2"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -3,7 +3,7 @@ from typing import Tuple
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version__ = "0.23.1"
+__version__ = "0.23.2"
 __author__ = "ethteck"
 
 from . import util as util

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -3,7 +3,7 @@ from typing import Tuple
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version__ = "0.22.1"
+__version__ = "0.22.2"
 __author__ = "ethteck"
 
 from . import util as util

--- a/src/splat/segtypes/common/code.py
+++ b/src/splat/segtypes/common/code.py
@@ -102,10 +102,11 @@ class CommonSegCode(CommonSegGroup):
             if seg.is_text():
                 last_inserted_index = i
 
-            elif self.section_order.index(".rodata") < self.section_order.index(".text"):
+            elif self.section_order.index(".rodata") < self.section_order.index(
+                ".text"
+            ):
                 if seg.is_rodata():
                     last_inserted_index = i
-
 
         for i, sect in enumerate(options.opts.auto_all_sections):
             for name, seg in base_segments_list:
@@ -131,7 +132,10 @@ class CommonSegCode(CommonSegGroup):
             # Advance last_inserted_index for any segment of a type that we have already seen
             while last_inserted_index < len(ret):
                 link_section = ret[last_inserted_index].get_linker_section_order()
-                if link_section != "" and link_section not in options.opts.auto_all_sections[:i+1]:
+                if (
+                    link_section != ""
+                    and link_section not in options.opts.auto_all_sections[: i + 1]
+                ):
                     last_inserted_index -= 1
                     break
                 last_inserted_index += 1

--- a/src/splat/segtypes/common/code.py
+++ b/src/splat/segtypes/common/code.py
@@ -137,6 +137,8 @@ class CommonSegCode(CommonSegGroup):
                     and link_section not in options.opts.auto_all_sections[: i + 1]
                 ):
                     last_inserted_index -= 1
+                    if last_inserted_index < 0:
+                        last_inserted_index = 0
                     break
                 last_inserted_index += 1
 

--- a/src/splat/segtypes/common/code.py
+++ b/src/splat/segtypes/common/code.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import OrderedDict, List, Optional, Type
+from typing import OrderedDict, List, Optional, Type, Tuple
 
 from ...util import log, options
 
@@ -94,7 +94,7 @@ class CommonSegCode(CommonSegGroup):
         if len(options.opts.auto_all_sections) == 0:
             return ret
 
-        base_segments_list: list[tuple[str, Segment]] = list(base_segments.items())
+        base_segments_list: List[Tuple[str, Segment]] = list(base_segments.items())
 
         # Determine what will be the min insertion index
         last_inserted_index = len(base_segments_list) - 1

--- a/src/splat/segtypes/common/code.py
+++ b/src/splat/segtypes/common/code.py
@@ -96,19 +96,6 @@ class CommonSegCode(CommonSegGroup):
 
         base_segments_list: list[tuple[str, Segment]] = list(base_segments.items())
 
-        print()
-
-        # Determine what will be the min insertion index
-        last_inserted_index = len(ret)
-        for sect in reversed(self.section_order):
-            print()
-
-            print(sect)
-            for i, (name, seg) in enumerate(base_segments_list):
-                if seg.get_linker_section_order() == sect:
-                    continue
-                # print(f"    picking up {i} {seg}")
-                last_inserted_index = i
         last_inserted_index = len(base_segments_list) - 1
 
         for i, sect in enumerate(options.opts.auto_all_sections):
@@ -126,11 +113,11 @@ class CommonSegCode(CommonSegGroup):
                     )
                     seg.siblings[sect] = sibling
                     last_inserted_index += 1
-                    print(f" Inserting into {last_inserted_index}: {sibling}, between {ret[last_inserted_index-1:last_inserted_index+1]}")
                     ret.insert(last_inserted_index, sibling)
 
                 last_inserted_index = ret.index(sibling)
 
+            # Advance last_inserted_index for any segment of a type that we have already seen
             while last_inserted_index < len(ret):
                 if ret[last_inserted_index].get_linker_section_order() not in options.opts.auto_all_sections[:i+1]:
                     last_inserted_index -= 1

--- a/src/splat/segtypes/common/pad.py
+++ b/src/splat/segtypes/common/pad.py
@@ -19,5 +19,11 @@ class LinkerEntryPad(LinkerEntry):
 
 
 class CommonSegPad(CommonSegment):
+    def get_linker_section_order(self) -> str:
+        return ""
+
+    def get_linker_section_linksection(self) -> str:
+        return ""
+
     def get_linker_entries(self) -> List[LinkerEntry]:
         return [LinkerEntryPad(self)]

--- a/src/splat/segtypes/n64/linker_offset.py
+++ b/src/splat/segtypes/n64/linker_offset.py
@@ -19,5 +19,11 @@ class LinkerEntryOffset(LinkerEntry):
 
 
 class N64SegLinker_offset(N64Segment):
+    def get_linker_section_order(self) -> str:
+        return ""
+
+    def get_linker_section_linksection(self) -> str:
+        return ""
+
     def get_linker_entries(self) -> List[LinkerEntry]:
         return [LinkerEntryOffset(self)]


### PR DESCRIPTION
Fixed a bug where auto segments insertion may not respect the proper ordering if there are linker_offset segments present