### PR TITLE
Don't set mips_abi_float_regs in create_config script

### DIFF
--- a/src/splat/scripts/create_config.py
+++ b/src/splat/scripts/create_config.py
@@ -60,7 +60,6 @@ options:
 
   o_as_suffix: True
   use_legacy_include_asm: False
-  mips_abi_float_regs: o32
 
   asm_function_macro: glabel
   asm_jtbl_label_macro: jlabel

--- a/src/splat/util/options.py
+++ b/src/splat/util/options.py
@@ -491,13 +491,13 @@ def _parse_yaml(
         mips_abi_gpr=p.parse_opt_within(
             "mips_abi_gpr",
             str,
-            ["numeric", "o32", "n32", "n64"],
+            ["numeric", "32", "o32", "n32", "n64"],
             "o32",
         ),
         mips_abi_float_regs=p.parse_opt_within(
             "mips_abi_float_regs",
             str,
-            ["numeric", "o32", "n32", "n64"],
+            ["numeric", "32", "o32", "n32", "n64"],
             "numeric",
         ),
         named_regs_for_c_funcs=p.parse_opt("named_regs_for_c_funcs", bool, True),


### PR DESCRIPTION
also align the allowed values with the [same values](https://github.com/Decompollaborate/spimdisasm/blob/0ef84068be2e75b5fd2241a79ac7b837d9f4ac3c/spimdisasm/mips/InstructionConfig.py#L22) as spimdisasm.