### PR TITLE
Add `mips_abi_float_regs` option back to `create_config` and add some docs

### DIFF
--- a/src/splat/scripts/create_config.py
+++ b/src/splat/scripts/create_config.py
@@ -60,6 +60,7 @@ options:
 
   o_as_suffix: True
   use_legacy_include_asm: False
+  mips_abi_float_regs: o32
 
   asm_function_macro: glabel
   asm_jtbl_label_macro: jlabel

--- a/src/splat/segtypes/common/data.py
+++ b/src/splat/segtypes/common/data.py
@@ -142,7 +142,7 @@ class CommonSegData(CommonSegCodeSubsegment, CommonSegGroup):
                 if symbol.contextSym.isJumpTable():
                     rodata_encountered = True
                     print(
-                        f"Data segment {self.name}, symbol at vram {symbol.contextSym.vram:X} is a jumptable, indicating the start of the rodata section _may_ be near here."
+                        f"\n\nData segment {self.name}, symbol at vram {symbol.contextSym.vram:X} is a jumptable, indicating the start of the rodata section _may_ be near here."
                     )
                     print(
                         "Please note the real start of the rodata section may be way before this point."


### PR DESCRIPTION
Adds `mips_abi_float_regs` back to `create_config` and add some explanation about it in `General-Workflow.md` and how to setup the `macro.inc` file expected by splat.

I also updated the `Quickstart.md` example with the new output