### PR TITLE
Fix linker script generation not respecting other noload segments (like `.sbss`) when using `bss_contains_common`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # splat Release Notes
 
+### 0.22.3
+
+* Fix linker script generation not respecting other noload segments (like `.sbss`) when using `bss_contains_common`.
+
 ### 0.22.2
 
 * Allow for `image_type_in_extension` to be overridden by subclasses of N64SegImg

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The brackets corresponds to the optional dependencies to install while installin
 If you use a `requirements.txt` file in your repository, then you can add this library with the following line:
 
 ```txt
-splat64[mips]>=0.22.1,<1.0.0
+splat64[mips]>=0.22.3,<1.0.0
 ```
 
 ### Optional dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.22.1"
+version = "0.22.3"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -3,7 +3,7 @@ from typing import Tuple
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version__ = "0.22.1"
+__version__ = "0.22.3"
 __author__ = "ethteck"
 
 from . import util as util

--- a/src/splat/segtypes/linker_entry.py
+++ b/src/splat/segtypes/linker_entry.py
@@ -168,7 +168,7 @@ class LinkerEntry:
 
         if self.noload and self.bss_contains_common:
             linker_writer._write_object_path_section(
-                self.object_path, ".bss COMMON .scommon"
+                self.object_path, f"{self.section_link} COMMON .scommon"
             )
         else:
             wildcard = "*" if options.opts.ld_wildcard_sections else ""


### PR DESCRIPTION
We noted this problem in parappa 2