### PR TITLE
Change `sbss` to properly behave as noload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 ### 0.21.11
 
 * Show an error on `create_config` if the format is not supported.
-* Allow lib segment to be a dictionary with `objec t` and `section` options
+* Allow lib segment to be a dictionary with `object` and `section` options
 * Allow lib segment to use `vram` option
 
 ### 0.21.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # splat Release Notes
 
+### 0.22.4
+
+* Change `sbss` to properly work as a noload section.
+  * To make it not behave as noload then turn off `ld_bss_is_noload`.
+
 ### 0.22.3
 
 * Fix linker script generation not respecting other noload segments (like `.sbss`) when using `bss_contains_common`.
@@ -30,7 +35,7 @@
 ### 0.21.11
 
 * Show an error on `create_config` if the format is not supported.
-* Allow lib segment to be a dictionary with `object` and `section` options
+* Allow lib segment to be a dictionary with `objec t` and `section` options
 * Allow lib segment to use `vram` option
 
 ### 0.21.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Change `sbss` to properly work as a noload section.
   * To make it not behave as noload then turn off `ld_bss_is_noload`.
+* `ld_bss_is_noload` is now `False` by default for `psx` projects.
 
 ### 0.22.3
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The brackets corresponds to the optional dependencies to install while installin
 If you use a `requirements.txt` file in your repository, then you can add this library with the following line:
 
 ```txt
-splat64[mips]>=0.22.3,<1.0.0
+splat64[mips]>=0.22.4,<1.0.0
 ```
 
 ### Optional dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.22.3"
+version = "0.22.4"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -3,7 +3,7 @@ from typing import Tuple
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version__ = "0.22.3"
+__version__ = "0.22.4"
 __author__ = "ethteck"
 
 from . import util as util

--- a/src/splat/segtypes/common/bss.py
+++ b/src/splat/segtypes/common/bss.py
@@ -4,6 +4,8 @@ from .data import CommonSegData
 
 from ...disassembler.disassembler_section import make_bss_section
 
+# If `options.opts.ld_bss_is_noload` is False, then this segment behaves like a `CommonSegData`
+
 
 class CommonSegBss(CommonSegData):
     def get_linker_section(self) -> str:
@@ -11,6 +13,8 @@ class CommonSegBss(CommonSegData):
 
     @staticmethod
     def is_data() -> bool:
+        if not options.opts.ld_bss_is_noload:
+            return True
         return False
 
     @staticmethod
@@ -20,6 +24,10 @@ class CommonSegBss(CommonSegData):
         return True
 
     def disassemble_data(self, rom_bytes: bytes):
+        if not options.opts.ld_bss_is_noload:
+            super().disassemble_data(rom_bytes)
+            return
+
         if not isinstance(self.rom_start, int):
             log.error(
                 f"Segment '{self.name}' (type '{self.type}') requires a rom_start. Got '{self.rom_start}'"
@@ -65,4 +73,6 @@ class CommonSegBss(CommonSegData):
             )
 
     def should_scan(self) -> bool:
+        if not options.opts.ld_bss_is_noload:
+            return super().should_scan()
         return options.opts.is_mode_active("code") and self.vram_start is not None

--- a/src/splat/segtypes/common/sbss.py
+++ b/src/splat/segtypes/common/sbss.py
@@ -1,6 +1,6 @@
-from .data import CommonSegData
+from .bss import CommonSegBss
 
 
-class CommonSegSbss(CommonSegData):
+class CommonSegSbss(CommonSegBss):
     def get_linker_section(self) -> str:
         return ".sbss"

--- a/src/splat/util/options.py
+++ b/src/splat/util/options.py
@@ -452,7 +452,9 @@ def _parse_yaml(
         ),
         ld_rom_start=p.parse_opt("ld_rom_start", int, 0),
         ld_fill_value=p.parse_optional_opt_with_default("ld_fill_value", int, 0),
-        ld_bss_is_noload=p.parse_opt("ld_bss_is_noload", bool, default_ld_bss_is_noload),
+        ld_bss_is_noload=p.parse_opt(
+            "ld_bss_is_noload", bool, default_ld_bss_is_noload
+        ),
         ld_align_segment_vram_end=p.parse_opt("ld_align_segment_vram_end", bool, True),
         ld_align_section_vram_end=p.parse_opt("ld_align_section_vram_end", bool, True),
         ld_generate_symbol_per_data_segment=p.parse_opt(

--- a/src/splat/util/options.py
+++ b/src/splat/util/options.py
@@ -364,6 +364,10 @@ def _parse_yaml(
         else:
             raise ValueError(f"Invalid endianness: {endianness}")
 
+    default_ld_bss_is_noload = True
+    if platform == "psx":
+        default_ld_bss_is_noload = False
+
     ret = SplatOpts(
         verbose=verbose,
         dump_symbols=p.parse_opt("dump_symbols", bool, False),
@@ -448,7 +452,7 @@ def _parse_yaml(
         ),
         ld_rom_start=p.parse_opt("ld_rom_start", int, 0),
         ld_fill_value=p.parse_optional_opt_with_default("ld_fill_value", int, 0),
-        ld_bss_is_noload=p.parse_opt("ld_bss_is_noload", bool, True),
+        ld_bss_is_noload=p.parse_opt("ld_bss_is_noload", bool, default_ld_bss_is_noload),
         ld_align_segment_vram_end=p.parse_opt("ld_align_segment_vram_end", bool, True),
         ld_align_section_vram_end=p.parse_opt("ld_align_section_vram_end", bool, True),
         ld_generate_symbol_per_data_segment=p.parse_opt(


### PR DESCRIPTION
Now both `bss` and `sbss` behave as noload by default.

To make those sections to not behave as noload then turn off `ld_bss_is_noload`.

Also, since psx projects seem to usually use `ld_bss_is_noload` turned off by default then I made it to be turned of for psx projects.

I tested it on a ps2 project and it works as expected, but I haven't tested it on a psx project yet