### PR TITLE
Set ABI for ps2

### DIFF
--- a/src/splat/disassembler/spimdisasm_disassembler.py
+++ b/src/splat/disassembler/spimdisasm_disassembler.py
@@ -110,9 +110,6 @@ class SpimdisasmDisassembler(disassembler.Disassembler):
             options.opts.disasm_unknown
         )
 
-        if options.opts.compiler == compiler.GCC and options.opts.platform == "ps2":
-            rabbitizer.config.toolchainTweaks_treatJAsUnconditionalBranch = False
-
     def check_version(self, skip_version_check: bool, splat_version: str):
         if not skip_version_check and spimdisasm.__version_info__ < self.SPIMDISASM_MIN:
             log.error(

--- a/src/splat/platforms/ps2.py
+++ b/src/splat/platforms/ps2.py
@@ -3,6 +3,7 @@ import rabbitizer
 
 from ..util import compiler, options
 
+
 def init(target_bytes: bytes):
     rabbitizer.config.toolchainTweaks_treatJAsUnconditionalBranch = False
 

--- a/src/splat/platforms/ps2.py
+++ b/src/splat/platforms/ps2.py
@@ -1,2 +1,7 @@
+import rabbitizer
+
+from ..util import compiler, options
+
 def init(target_bytes: bytes):
-    pass
+    if options.opts.compiler == compiler.GCC:
+        rabbitizer.config.toolchainTweaks_treatJAsUnconditionalBranch = False

--- a/src/splat/platforms/ps2.py
+++ b/src/splat/platforms/ps2.py
@@ -1,3 +1,4 @@
+import spimdisasm
 import rabbitizer
 
 from ..util import compiler, options
@@ -5,3 +6,5 @@ from ..util import compiler, options
 def init(target_bytes: bytes):
     if options.opts.compiler == compiler.GCC:
         rabbitizer.config.toolchainTweaks_treatJAsUnconditionalBranch = False
+
+    spimdisasm.common.GlobalConfig.ABI = spimdisasm.common.Abi.EABI64

--- a/src/splat/platforms/ps2.py
+++ b/src/splat/platforms/ps2.py
@@ -4,7 +4,6 @@ import rabbitizer
 from ..util import compiler, options
 
 def init(target_bytes: bytes):
-    if options.opts.compiler == compiler.GCC:
-        rabbitizer.config.toolchainTweaks_treatJAsUnconditionalBranch = False
+    rabbitizer.config.toolchainTweaks_treatJAsUnconditionalBranch = False
 
     spimdisasm.common.GlobalConfig.ABI = spimdisasm.common.Abi.EABI64


### PR DESCRIPTION
Set spimdisasm's ABI config to EABI64 when the platform is ps2.
This can help a little bit since spimdisasm has some checks in place for the o32 ABI (the default) that are bad for ps2 games (like double float detection on odd float registers).

Also moved the ps2 settings from `spimdisasm_disassembler.py` to `platforms/ps2.py`