### PR TITLE
Add a few ps2 segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * New ps2-specific segments:
   * `lit4` and `lit8`: "Literal" sections that only contain `float`s and `double`s respectively.
   * `ctor`: Data pointing to C++ global data initialization functions.
+  * `vtables`: C++ vtables
 * `spimdisasm` 1.23.0 or above is now required.
 
 ### 0.22.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   * To make it not behave as noload then turn off `ld_bss_is_noload`.
 * `ld_bss_is_noload` is now `False` by default for `psx` projects.
 * Allow to properly override `get_linker_section` and `get_section_flags` in `asm` and `hasm` files.
+* Allow configuring the `spimdisasm` section on extension segments (that inherit from `asm`, `data`, `rodata` or `bss` segments) before running the analisys on it.
+  * This is done by overriding the `configure_disassembler_section` method.
+* `spimdisasm` 1.23.0 or above is now required.
 
 ### 0.22.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 * Allow configuring the `spimdisasm` section on extension segments (that inherit from `asm`, `data`, `rodata` or `bss` segments) before running the analisys on it.
   * This is done by overriding the `configure_disassembler_section` method.
 * New ps2-specific segments:
-  * `lit4` and `lit8`: Literal sections that only contain `float`s and `double`s respectively.
+  * `lit4` and `lit8`: "Literal" sections that only contain `float`s and `double`s respectively.
+  * `ctor`: Data pointing to C++ global data initialization functions.
 * `spimdisasm` 1.23.0 or above is now required.
 
 ### 0.22.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 * Allow to properly override `get_linker_section` and `get_section_flags` in `asm` and `hasm` files.
 * Allow configuring the `spimdisasm` section on extension segments (that inherit from `asm`, `data`, `rodata` or `bss` segments) before running the analisys on it.
   * This is done by overriding the `configure_disassembler_section` method.
+* New ps2-specific segments:
+  * `lit4` and `lit8`: Literal sections that only contain `float`s and `double`s respectively.
 * `spimdisasm` 1.23.0 or above is now required.
 
 ### 0.22.3

--- a/docs/Segments.md
+++ b/docs/Segments.md
@@ -275,6 +275,32 @@ While this kind of segment can be represented by other segment types ([`asm`](#a
 - [0x00B250, pad, nops_00B250]
 ```
 
+## PS2 exclusive segments
+
+### `lit4`
+
+`lit4` is a segment that only contains single-precision floats.
+
+splat will try to disassemble all the data from this segment as individual floats whenever possible.
+
+### `lit8`
+
+`lit8` is a segment that only contains double-precision floats.
+
+splat will try to disassemble all the data from this segment as individual doubles whenever possible.
+
+### `ctor`
+
+`ctor` is used by certain compilers (like MWCC) to store pointers to functions that initialize C++ global data objects.
+
+The disassembly of this section is tweaked to avoid confusing its data with other types of data, this is because the disassembler can sometimes get confused and disassemble a pointer as a float, string, etc.
+
+### `vtables`
+
+`vtables` is used by certain compilers (like MWCC) to store the virtual tables of C++ classes
+
+The disassembly of this section is tweaked to avoid confusing its data with other types of data, this is because the disassembler can sometimes get confused and disassemble a pointer as a float, string, etc.
+
 ## General segment options
 
 All splat's segments can be passed extra options for finer configuration. Note that those extra options require to rewrite the entry using the dictionary yaml notation instead of the list one.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 
 [project.optional-dependencies]
 mips = [
-    "spimdisasm>=1.21.0,<2.0.0", # This value should be keep in sync with the version listed on disassembler/spimdisasm_disassembler.py
+    "spimdisasm>=1.23.0,<2.0.0", # This value should be keep in sync with the version listed on disassembler/spimdisasm_disassembler.py
     "rabbitizer>=1.8.0,<2.0.0",
     "pygfxd",
     "n64img>=0.1.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ pylibyaml
 tqdm
 intervaltree
 colorama
-# This value should be keep in sync with the version listed on disassembler/spimdisasm_disassembler.py
-spimdisasm>=1.21.0
+# This value should be keep in sync with the version listed on disassembler/spimdisasm_disassembler.py and pyproject.toml
+spimdisasm>=1.23.0
 rabbitizer>=1.8.0
 pygfxd
 n64img>=0.1.4

--- a/src/splat/disassembler/spimdisasm_disassembler.py
+++ b/src/splat/disassembler/spimdisasm_disassembler.py
@@ -6,8 +6,8 @@ from typing import Set
 
 
 class SpimdisasmDisassembler(disassembler.Disassembler):
-    # This value should be kept in sync with the version listed on requirements.txt
-    SPIMDISASM_MIN = (1, 21, 0)
+    # This value should be kept in sync with the version listed on requirements.txt and pyproject.toml
+    SPIMDISASM_MIN = (1, 23, 0)
 
     def configure(self):
         # Configure spimdisasm

--- a/src/splat/segtypes/common/bss.py
+++ b/src/splat/segtypes/common/bss.py
@@ -23,7 +23,9 @@ class CommonSegBss(CommonSegData):
             return False
         return True
 
-    def configure_disassembler_section(self, disassembler_section: DisassemblerSection) -> None:
+    def configure_disassembler_section(
+        self, disassembler_section: DisassemblerSection
+    ) -> None:
         "Allows to configure the section before running the analysis on it"
 
         pass

--- a/src/splat/segtypes/common/bss.py
+++ b/src/splat/segtypes/common/bss.py
@@ -2,7 +2,7 @@ from ...util import options, symbols, log
 
 from .data import CommonSegData
 
-from ...disassembler.disassembler_section import make_bss_section
+from ...disassembler.disassembler_section import DisassemblerSection, make_bss_section
 
 # If `options.opts.ld_bss_is_noload` is False, then this segment behaves like a `CommonSegData`
 
@@ -22,6 +22,11 @@ class CommonSegBss(CommonSegData):
         if not options.opts.ld_bss_is_noload:
             return False
         return True
+
+    def configure_disassembler_section(self, disassembler_section: DisassemblerSection) -> None:
+        "Allows to configure the section before running the analysis on it"
+
+        pass
 
     def disassemble_data(self, rom_bytes: bytes):
         if not options.opts.ld_bss_is_noload:
@@ -63,6 +68,8 @@ class CommonSegBss(CommonSegData):
         )
 
         assert self.spim_section is not None
+
+        self.configure_disassembler_section(self.spim_section)
 
         self.spim_section.analyze()
         self.spim_section.set_comment_offset(self.rom_start)

--- a/src/splat/segtypes/common/codesubsegment.py
+++ b/src/splat/segtypes/common/codesubsegment.py
@@ -53,7 +53,6 @@ class CommonSegCodeSubsegment(Segment):
         "Allows to configure the section before running the analysis on it"
 
         section = disassembler_section.get_section()
-        assert isinstance(section, spimdisasm.mips.sections.SectionText)
 
         section.isHandwritten = self.is_hasm
         section.instrCat = self.instr_category

--- a/src/splat/segtypes/common/codesubsegment.py
+++ b/src/splat/segtypes/common/codesubsegment.py
@@ -47,7 +47,9 @@ class CommonSegCodeSubsegment(Segment):
     def get_linker_section(self) -> str:
         return ".text"
 
-    def configure_disassembler_section(self, disassembler_section: DisassemblerSection) -> None:
+    def configure_disassembler_section(
+        self, disassembler_section: DisassemblerSection
+    ) -> None:
         "Allows to configure the section before running the analysis on it"
 
         section = disassembler_section.get_section()
@@ -56,7 +58,6 @@ class CommonSegCodeSubsegment(Segment):
         section.isHandwritten = self.is_hasm
         section.instrCat = self.instr_category
         section.detectRedundantFunctionEnd = self.detect_redundant_function_end
-
 
     def scan_code(self, rom_bytes, is_hasm=False):
         self.is_hasm = is_hasm

--- a/src/splat/segtypes/common/data.py
+++ b/src/splat/segtypes/common/data.py
@@ -1,8 +1,5 @@
 from pathlib import Path
 from typing import Optional
-
-import spimdisasm
-
 from ...util import options, symbols, log
 
 from .codesubsegment import CommonSegCodeSubsegment
@@ -90,7 +87,6 @@ class CommonSegData(CommonSegCodeSubsegment, CommonSegGroup):
         "Allows to configure the section before running the analysis on it"
 
         section = disassembler_section.get_section()
-        assert isinstance(section, spimdisasm.mips.sections.SectionBase)
 
         # Set data string encoding
         # First check the global configuration

--- a/src/splat/segtypes/common/data.py
+++ b/src/splat/segtypes/common/data.py
@@ -84,7 +84,9 @@ class CommonSegData(CommonSegCodeSubsegment, CommonSegGroup):
     def get_linker_entries(self):
         return CommonSegCodeSubsegment.get_linker_entries(self)
 
-    def configure_disassembler_section(self, disassembler_section: DisassemblerSection) -> None:
+    def configure_disassembler_section(
+        self, disassembler_section: DisassemblerSection
+    ) -> None:
         "Allows to configure the section before running the analysis on it"
 
         section = disassembler_section.get_section()

--- a/src/splat/segtypes/common/data.py
+++ b/src/splat/segtypes/common/data.py
@@ -1,12 +1,14 @@
 from pathlib import Path
 from typing import Optional
 
+import spimdisasm
+
 from ...util import options, symbols, log
 
 from .codesubsegment import CommonSegCodeSubsegment
 from .group import CommonSegGroup
 
-from ...disassembler.disassembler_section import make_data_section
+from ...disassembler.disassembler_section import DisassemblerSection, make_data_section
 
 
 class CommonSegData(CommonSegCodeSubsegment, CommonSegGroup):
@@ -82,6 +84,21 @@ class CommonSegData(CommonSegCodeSubsegment, CommonSegGroup):
     def get_linker_entries(self):
         return CommonSegCodeSubsegment.get_linker_entries(self)
 
+    def configure_disassembler_section(self, disassembler_section: DisassemblerSection) -> None:
+        "Allows to configure the section before running the analysis on it"
+
+        section = disassembler_section.get_section()
+        assert isinstance(section, spimdisasm.mips.sections.SectionBase)
+
+        # Set data string encoding
+        # First check the global configuration
+        if options.opts.data_string_encoding is not None:
+            section.stringEncoding = options.opts.data_string_encoding
+
+        # Then check the per-segment configuration in case we want to override the global one
+        if self.str_encoding is not None:
+            section.stringEncoding = self.str_encoding
+
     def disassemble_data(self, rom_bytes):
         if not isinstance(self.rom_start, int):
             log.error(
@@ -112,16 +129,7 @@ class CommonSegData(CommonSegCodeSubsegment, CommonSegGroup):
 
         assert self.spim_section is not None
 
-        # Set rodata string encoding
-        # First check the global configuration
-        if options.opts.data_string_encoding is not None:
-            self.spim_section.get_section().stringEncoding = (
-                options.opts.data_string_encoding
-            )
-
-        # Then check the per-segment configuration in case we want to override the global one
-        if self.str_encoding is not None:
-            self.spim_section.get_section().stringEncoding = self.str_encoding
+        self.configure_disassembler_section(self.spim_section)
 
         self.spim_section.analyze()
         self.spim_section.set_comment_offset(self.rom_start)

--- a/src/splat/segtypes/common/rodata.py
+++ b/src/splat/segtypes/common/rodata.py
@@ -5,7 +5,7 @@ from ...util import log, options, symbols
 
 from .data import CommonSegData
 
-from ...disassembler.disassembler_section import make_rodata_section
+from ...disassembler.disassembler_section import DisassemblerSection, make_rodata_section
 
 
 class CommonSegRodata(CommonSegData):
@@ -41,6 +41,21 @@ class CommonSegRodata(CommonSegData):
             return None
         return text_segment, func
 
+    def configure_disassembler_section(self, disassembler_section: DisassemblerSection) -> None:
+        "Allows to configure the section before running the analysis on it"
+
+        section = disassembler_section.get_section()
+        assert isinstance(section, spimdisasm.mips.sections.SectionBase)
+
+        # Set rodata string encoding
+        # First check the global configuration
+        if options.opts.string_encoding is not None:
+            section.stringEncoding = options.opts.string_encoding
+
+        # Then check the per-segment configuration in case we want to override the global one
+        if self.str_encoding is not None:
+            section.stringEncoding = self.str_encoding
+
     def disassemble_data(self, rom_bytes):
         if not isinstance(self.rom_start, int):
             log.error(
@@ -71,16 +86,7 @@ class CommonSegRodata(CommonSegData):
 
         assert self.spim_section is not None
 
-        # Set rodata string encoding
-        # First check the global configuration
-        if options.opts.string_encoding is not None:
-            self.spim_section.get_section().stringEncoding = (
-                options.opts.string_encoding
-            )
-
-        # Then check the per-segment configuration in case we want to override the global one
-        if self.str_encoding is not None:
-            self.spim_section.get_section().stringEncoding = self.str_encoding
+        self.configure_disassembler_section(self.spim_section)
 
         self.spim_section.analyze()
         self.spim_section.set_comment_offset(self.rom_start)

--- a/src/splat/segtypes/common/rodata.py
+++ b/src/splat/segtypes/common/rodata.py
@@ -50,7 +50,6 @@ class CommonSegRodata(CommonSegData):
         "Allows to configure the section before running the analysis on it"
 
         section = disassembler_section.get_section()
-        assert isinstance(section, spimdisasm.mips.sections.SectionBase)
 
         # Set rodata string encoding
         # First check the global configuration

--- a/src/splat/segtypes/common/rodata.py
+++ b/src/splat/segtypes/common/rodata.py
@@ -5,7 +5,10 @@ from ...util import log, options, symbols
 
 from .data import CommonSegData
 
-from ...disassembler.disassembler_section import DisassemblerSection, make_rodata_section
+from ...disassembler.disassembler_section import (
+    DisassemblerSection,
+    make_rodata_section,
+)
 
 
 class CommonSegRodata(CommonSegData):
@@ -41,7 +44,9 @@ class CommonSegRodata(CommonSegData):
             return None
         return text_segment, func
 
-    def configure_disassembler_section(self, disassembler_section: DisassemblerSection) -> None:
+    def configure_disassembler_section(
+        self, disassembler_section: DisassemblerSection
+    ) -> None:
         "Allows to configure the section before running the analysis on it"
 
         section = disassembler_section.get_section()

--- a/src/splat/segtypes/ps2/ctor.py
+++ b/src/splat/segtypes/ps2/ctor.py
@@ -1,7 +1,5 @@
 from typing import Optional
 
-import spimdisasm
-
 from ..common.data import CommonSegData
 from ...disassembler.disassembler_section import DisassemblerSection
 
@@ -23,7 +21,6 @@ class Ps2SegCtor(CommonSegData):
         super().configure_disassembler_section(disassembler_section)
 
         section = disassembler_section.get_section()
-        assert isinstance(section, spimdisasm.mips.sections.SectionBase)
 
         # We use s32 to make sure spimdisasm disassembles the data from this section as words/references to other symbols
         section.enableStringGuessing = False

--- a/src/splat/segtypes/ps2/ctor.py
+++ b/src/splat/segtypes/ps2/ctor.py
@@ -15,7 +15,9 @@ class PS2SegCtor(CommonSegData):
     def get_section_flags(self) -> Optional[str]:
         return "a"
 
-    def configure_disassembler_section(self, disassembler_section: DisassemblerSection) -> None:
+    def configure_disassembler_section(
+        self, disassembler_section: DisassemblerSection
+    ) -> None:
         "Allows to configure the section before running the analysis on it"
 
         super().configure_disassembler_section(disassembler_section)

--- a/src/splat/segtypes/ps2/ctor.py
+++ b/src/splat/segtypes/ps2/ctor.py
@@ -6,14 +6,14 @@ from ..common.data import CommonSegData
 from ...disassembler.disassembler_section import DisassemblerSection
 
 
-class PS2SegLit8(CommonSegData):
-    """Segment that only contains double-precision floats"""
+class PS2SegCtor(CommonSegData):
+    """Segment that only contains a pointer to C++ global data initialization functions"""
 
     def get_linker_section(self) -> str:
-        return ".lit8"
+        return ".ctor"
 
     def get_section_flags(self) -> Optional[str]:
-        return "wa"
+        return "a"
 
     def configure_disassembler_section(self, disassembler_section: DisassemblerSection) -> None:
         "Allows to configure the section before running the analysis on it"
@@ -23,7 +23,6 @@ class PS2SegLit8(CommonSegData):
         section = disassembler_section.get_section()
         assert isinstance(section, spimdisasm.mips.sections.SectionBase)
 
-        # Tell spimdisasm this section only contains doubles
         section.enableStringGuessing = False
-        section.typeForOwnedSymbols = "f64"
-        section.sizeForOwnedSymbols = 8
+        section.typeForOwnedSymbols = "s32"
+        section.sizeForOwnedSymbols = 4

--- a/src/splat/segtypes/ps2/ctor.py
+++ b/src/splat/segtypes/ps2/ctor.py
@@ -6,7 +6,7 @@ from ..common.data import CommonSegData
 from ...disassembler.disassembler_section import DisassemblerSection
 
 
-class PS2SegCtor(CommonSegData):
+class Ps2SegCtor(CommonSegData):
     """Segment that contains pointers to C++ global data initialization functions"""
 
     def get_linker_section(self) -> str:

--- a/src/splat/segtypes/ps2/lit4.py
+++ b/src/splat/segtypes/ps2/lit4.py
@@ -1,0 +1,26 @@
+from typing import Optional
+
+import spimdisasm
+
+from ..common.data import CommonSegData
+from ...disassembler.disassembler_section import DisassemblerSection
+
+
+class PS2SegLit4(CommonSegData):
+    """Segment that only contains single-precision floats"""
+
+    def get_linker_section(self) -> str:
+        return ".lit4"
+
+    def get_section_flags(self) -> Optional[str]:
+        return "wa"
+
+    def configure_disassembler_section(self, disassembler_section: DisassemblerSection) -> None:
+        "Allows to configure the section before running the analysis on it"
+
+        section = disassembler_section.get_section()
+        assert isinstance(section, spimdisasm.mips.sections.SectionBase)
+
+        # Tell spimdisasm this section only contains floats
+        section.typeForOwnedSymbols = "f32"
+        section.sizeForOwnedSymbols = 4

--- a/src/splat/segtypes/ps2/lit4.py
+++ b/src/splat/segtypes/ps2/lit4.py
@@ -1,7 +1,5 @@
 from typing import Optional
 
-import spimdisasm
-
 from ..common.data import CommonSegData
 from ...disassembler.disassembler_section import DisassemblerSection
 
@@ -23,7 +21,6 @@ class Ps2SegLit4(CommonSegData):
         super().configure_disassembler_section(disassembler_section)
 
         section = disassembler_section.get_section()
-        assert isinstance(section, spimdisasm.mips.sections.SectionBase)
 
         # Tell spimdisasm this section only contains floats
         section.enableStringGuessing = False

--- a/src/splat/segtypes/ps2/lit4.py
+++ b/src/splat/segtypes/ps2/lit4.py
@@ -15,7 +15,9 @@ class PS2SegLit4(CommonSegData):
     def get_section_flags(self) -> Optional[str]:
         return "wa"
 
-    def configure_disassembler_section(self, disassembler_section: DisassemblerSection) -> None:
+    def configure_disassembler_section(
+        self, disassembler_section: DisassemblerSection
+    ) -> None:
         "Allows to configure the section before running the analysis on it"
 
         super().configure_disassembler_section(disassembler_section)

--- a/src/splat/segtypes/ps2/lit4.py
+++ b/src/splat/segtypes/ps2/lit4.py
@@ -18,9 +18,12 @@ class PS2SegLit4(CommonSegData):
     def configure_disassembler_section(self, disassembler_section: DisassemblerSection) -> None:
         "Allows to configure the section before running the analysis on it"
 
+        super().configure_disassembler_section(disassembler_section)
+
         section = disassembler_section.get_section()
         assert isinstance(section, spimdisasm.mips.sections.SectionBase)
 
         # Tell spimdisasm this section only contains floats
+        section.enableStringGuessing = False
         section.typeForOwnedSymbols = "f32"
         section.sizeForOwnedSymbols = 4

--- a/src/splat/segtypes/ps2/lit4.py
+++ b/src/splat/segtypes/ps2/lit4.py
@@ -6,7 +6,7 @@ from ..common.data import CommonSegData
 from ...disassembler.disassembler_section import DisassemblerSection
 
 
-class PS2SegLit4(CommonSegData):
+class Ps2SegLit4(CommonSegData):
     """Segment that only contains single-precision floats"""
 
     def get_linker_section(self) -> str:

--- a/src/splat/segtypes/ps2/lit8.py
+++ b/src/splat/segtypes/ps2/lit8.py
@@ -1,7 +1,5 @@
 from typing import Optional
 
-import spimdisasm
-
 from ..common.data import CommonSegData
 from ...disassembler.disassembler_section import DisassemblerSection
 
@@ -23,7 +21,6 @@ class Ps2SegLit8(CommonSegData):
         super().configure_disassembler_section(disassembler_section)
 
         section = disassembler_section.get_section()
-        assert isinstance(section, spimdisasm.mips.sections.SectionBase)
 
         # Tell spimdisasm this section only contains doubles
         section.enableStringGuessing = False

--- a/src/splat/segtypes/ps2/lit8.py
+++ b/src/splat/segtypes/ps2/lit8.py
@@ -1,0 +1,26 @@
+from typing import Optional
+
+import spimdisasm
+
+from ..common.data import CommonSegData
+from ...disassembler.disassembler_section import DisassemblerSection
+
+
+class PS2SegLit8(CommonSegData):
+    """Segment that only contains double-precision floats"""
+
+    def get_linker_section(self) -> str:
+        return ".lit8"
+
+    def get_section_flags(self) -> Optional[str]:
+        return "wa"
+
+    def configure_disassembler_section(self, disassembler_section: DisassemblerSection) -> None:
+        "Allows to configure the section before running the analysis on it"
+
+        section = disassembler_section.get_section()
+        assert isinstance(section, spimdisasm.mips.sections.SectionBase)
+
+        # Tell spimdisasm this section only contains doubles
+        section.typeForOwnedSymbols = "f64"
+        section.sizeForOwnedSymbols = 8

--- a/src/splat/segtypes/ps2/lit8.py
+++ b/src/splat/segtypes/ps2/lit8.py
@@ -6,7 +6,7 @@ from ..common.data import CommonSegData
 from ...disassembler.disassembler_section import DisassemblerSection
 
 
-class PS2SegLit8(CommonSegData):
+class Ps2SegLit8(CommonSegData):
     """Segment that only contains double-precision floats"""
 
     def get_linker_section(self) -> str:

--- a/src/splat/segtypes/ps2/lit8.py
+++ b/src/splat/segtypes/ps2/lit8.py
@@ -15,7 +15,9 @@ class PS2SegLit8(CommonSegData):
     def get_section_flags(self) -> Optional[str]:
         return "wa"
 
-    def configure_disassembler_section(self, disassembler_section: DisassemblerSection) -> None:
+    def configure_disassembler_section(
+        self, disassembler_section: DisassemblerSection
+    ) -> None:
         "Allows to configure the section before running the analysis on it"
 
         super().configure_disassembler_section(disassembler_section)

--- a/src/splat/segtypes/ps2/vtables.py
+++ b/src/splat/segtypes/ps2/vtables.py
@@ -6,11 +6,11 @@ from ..common.data import CommonSegData
 from ...disassembler.disassembler_section import DisassemblerSection
 
 
-class PS2SegCtor(CommonSegData):
-    """Segment that contains pointers to C++ global data initialization functions"""
+class PS2SegVtables(CommonSegData):
+    """Segment that contains a pointer to C++ vtables"""
 
     def get_linker_section(self) -> str:
-        return ".ctor"
+        return ".vtables"
 
     def get_section_flags(self) -> Optional[str]:
         return "a"

--- a/src/splat/segtypes/ps2/vtables.py
+++ b/src/splat/segtypes/ps2/vtables.py
@@ -6,7 +6,7 @@ from ..common.data import CommonSegData
 from ...disassembler.disassembler_section import DisassemblerSection
 
 
-class PS2SegVtables(CommonSegData):
+class Ps2SegVtables(CommonSegData):
     """Segment that contains a pointer to C++ vtables"""
 
     def get_linker_section(self) -> str:

--- a/src/splat/segtypes/ps2/vtables.py
+++ b/src/splat/segtypes/ps2/vtables.py
@@ -15,7 +15,9 @@ class PS2SegVtables(CommonSegData):
     def get_section_flags(self) -> Optional[str]:
         return "a"
 
-    def configure_disassembler_section(self, disassembler_section: DisassemblerSection) -> None:
+    def configure_disassembler_section(
+        self, disassembler_section: DisassemblerSection
+    ) -> None:
         "Allows to configure the section before running the analysis on it"
 
         super().configure_disassembler_section(disassembler_section)

--- a/src/splat/segtypes/ps2/vtables.py
+++ b/src/splat/segtypes/ps2/vtables.py
@@ -1,7 +1,5 @@
 from typing import Optional
 
-import spimdisasm
-
 from ..common.data import CommonSegData
 from ...disassembler.disassembler_section import DisassemblerSection
 
@@ -23,7 +21,6 @@ class Ps2SegVtables(CommonSegData):
         super().configure_disassembler_section(disassembler_section)
 
         section = disassembler_section.get_section()
-        assert isinstance(section, spimdisasm.mips.sections.SectionBase)
 
         # We use s32 to make sure spimdisasm disassembles the data from this section as words/references to other symbols
         section.enableStringGuessing = False

--- a/src/splat/segtypes/ps2/vtables.py
+++ b/src/splat/segtypes/ps2/vtables.py
@@ -28,4 +28,3 @@ class Ps2SegVtables(CommonSegData):
         # We use s32 to make sure spimdisasm disassembles the data from this section as words/references to other symbols
         section.enableStringGuessing = False
         section.typeForOwnedSymbols = "s32"
-        section.sizeForOwnedSymbols = 4


### PR DESCRIPTION
This sections are configured to behave in a very specific way, since we know the data they contain.
* `lit4` and `lit8`: "Literal" sections that only contain `float`s and `double`s respectively.
* `ctor`: Data pointing to C++ global data initialization functions.
* `vtables`: C++ vtables

One major missing ps2/c++ section is the `init` section (the `ctor` data points to symbols from this section).
The `init` section is another executable that is autogenerated by the compiler. It contains functions to initialize global or static C++ objects.
This PR does not include that section because I'm not sure yet how the workflow of migrating this section to the `.cpp` file would work like.
I have a WIP implementation that I'm toying with here, in case anybody wants to take a look at it: https://github.com/AngheloAlf/goin_quackers/blob/4e0fbcf165df1b1a4b4c924afd466fb1c3ef1bf4/tools/splat_ext/init.py

The other changes (like `configure_disassembler_section`) were made to make implementing the new segment types more easily