### PR TITLE
Remove `ld_section_labels`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * `ld_bss_is_noload` is now `False` by default for `psx` projects.
 * Allow to properly override `get_linker_section` and `get_section_flags` in `asm` and `hasm` files.
 * Fix disassembling segments that only have bss.
+* `ld_section_labels` was removed since it was a redundant list to `section_order`.
 
 ### 0.22.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Allow to properly override `get_linker_section` and `get_section_flags` in `asm` and `hasm` files.
 * Fix disassembling segments that only have bss.
 * `ld_section_labels` was removed since it was a redundant list to `section_order`.
+* Give a proper error message for missing sections on `section_order` during linker script generation.
 
 ### 0.22.3
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -369,10 +369,6 @@ ld_symbol_header_path: path/to/linker_symbol_header
 
 Determines whether to add a discard section to the linker script
 
-### ld_section_labels
-
-Determines the list of section labels that are to be added to the linker script
-
 ### ld_wildcard_sections
 
 Determines whether to add wildcards for section linking in the linker script (.rodata* for example)

--- a/src/splat/segtypes/linker_entry.py
+++ b/src/splat/segtypes/linker_entry.py
@@ -254,14 +254,14 @@ class LinkerWriter:
             if entry.section_order_type in section_entries:
                 if entry.section_order_type not in section_entries:
                     log.error(
-                        f"Error on linker script generation: section '{entry.section_order_type}' not found.\n  Make sure the section '{entry.section_order_type}' is listed on 'section_order' of the yaml options."
+                        f"\nError on linker script generation: section '{entry.section_order_type}' not found.\n  Make sure the section '{entry.section_order_type}' is listed on 'section_order' of the yaml options."
                     )
                 section_entries[entry.section_order_type].append(entry)
             elif prev_entry is not None:
                 # If this section is not present in section_order or section_order then pretend it is part of the last seen section, mainly for handling linker_offset
                 if prev_entry not in section_entries:
                     log.error(
-                        f"Error on linker script generation: section '{prev_entry}' not found.\n  Make sure the section '{prev_entry}' is listed on 'section_order' of the yaml options."
+                        f"\nError on linker script generation: section '{prev_entry}' not found.\n  Make sure the section '{prev_entry}' is listed on 'section_order' of the yaml options."
                     )
                 section_entries[prev_entry].append(entry)
             any_load = any_load or not entry.noload
@@ -429,14 +429,14 @@ class LinkerWriter:
             if entry.section_order_type in section_entries:
                 if entry.section_order_type not in section_entries:
                     log.error(
-                        f"Error on linker script generation: section '{entry.section_order_type}' not found.\n  Make sure the section '{entry.section_order_type}' is listed on 'section_order' of the yaml options."
+                        f"\nError on linker script generation: section '{entry.section_order_type}' not found.\n  Make sure the section '{entry.section_order_type}' is listed on 'section_order' of the yaml options."
                     )
                 section_entries[entry.section_order_type].append(entry)
             elif prev_entry is not None:
                 # If this section is not present in section_order or section_order then pretend it is part of the last seen section, mainly for handling linker_offset
                 if prev_entry not in section_entries:
                     log.error(
-                        f"Error on linker script generation: section '{prev_entry}' not found.\n  Make sure the section '{prev_entry}' is listed on 'section_order' of the yaml options."
+                        f"\nError on linker script generation: section '{prev_entry}' not found.\n  Make sure the section '{prev_entry}' is listed on 'section_order' of the yaml options."
                     )
                 section_entries[prev_entry].append(entry)
             prev_entry = entry.section_order_type

--- a/src/splat/segtypes/linker_entry.py
+++ b/src/splat/segtypes/linker_entry.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Dict, List, OrderedDict, Set, Tuple, Union, Optional
 
-from ..util import options
+from ..util import options, log
 
 from .segment import Segment
 from ..util.symbols import to_cname
@@ -252,9 +252,13 @@ class LinkerWriter:
         any_noload = False
         for entry in entries:
             if entry.section_order_type in section_entries:
+                if entry.section_order_type not in section_entries:
+                    log.error(f"Error on linker script generation: section '{entry.section_order_type}' not found.\n  Make sure the section '{entry.section_order_type}' is listed on 'section_order' of the yaml options.")
                 section_entries[entry.section_order_type].append(entry)
             elif prev_entry is not None:
                 # If this section is not present in section_order or section_order then pretend it is part of the last seen section, mainly for handling linker_offset
+                if prev_entry not in section_entries:
+                    log.error(f"Error on linker script generation: section '{prev_entry}' not found.\n  Make sure the section '{prev_entry}' is listed on 'section_order' of the yaml options.")
                 section_entries[prev_entry].append(entry)
             any_load = any_load or not entry.noload
             any_noload = any_noload or entry.noload
@@ -419,9 +423,13 @@ class LinkerWriter:
         prev_entry = None
         for entry in entries:
             if entry.section_order_type in section_entries:
+                if entry.section_order_type not in section_entries:
+                    log.error(f"Error on linker script generation: section '{entry.section_order_type}' not found.\n  Make sure the section '{entry.section_order_type}' is listed on 'section_order' of the yaml options.")
                 section_entries[entry.section_order_type].append(entry)
             elif prev_entry is not None:
                 # If this section is not present in section_order or section_order then pretend it is part of the last seen section, mainly for handling linker_offset
+                if prev_entry not in section_entries:
+                    log.error(f"Error on linker script generation: section '{prev_entry}' not found.\n  Make sure the section '{prev_entry}' is listed on 'section_order' of the yaml options.")
                 section_entries[prev_entry].append(entry)
             prev_entry = entry.section_order_type
 

--- a/src/splat/segtypes/linker_entry.py
+++ b/src/splat/segtypes/linker_entry.py
@@ -253,12 +253,16 @@ class LinkerWriter:
         for entry in entries:
             if entry.section_order_type in section_entries:
                 if entry.section_order_type not in section_entries:
-                    log.error(f"Error on linker script generation: section '{entry.section_order_type}' not found.\n  Make sure the section '{entry.section_order_type}' is listed on 'section_order' of the yaml options.")
+                    log.error(
+                        f"Error on linker script generation: section '{entry.section_order_type}' not found.\n  Make sure the section '{entry.section_order_type}' is listed on 'section_order' of the yaml options."
+                    )
                 section_entries[entry.section_order_type].append(entry)
             elif prev_entry is not None:
                 # If this section is not present in section_order or section_order then pretend it is part of the last seen section, mainly for handling linker_offset
                 if prev_entry not in section_entries:
-                    log.error(f"Error on linker script generation: section '{prev_entry}' not found.\n  Make sure the section '{prev_entry}' is listed on 'section_order' of the yaml options.")
+                    log.error(
+                        f"Error on linker script generation: section '{prev_entry}' not found.\n  Make sure the section '{prev_entry}' is listed on 'section_order' of the yaml options."
+                    )
                 section_entries[prev_entry].append(entry)
             any_load = any_load or not entry.noload
             any_noload = any_noload or entry.noload
@@ -424,12 +428,16 @@ class LinkerWriter:
         for entry in entries:
             if entry.section_order_type in section_entries:
                 if entry.section_order_type not in section_entries:
-                    log.error(f"Error on linker script generation: section '{entry.section_order_type}' not found.\n  Make sure the section '{entry.section_order_type}' is listed on 'section_order' of the yaml options.")
+                    log.error(
+                        f"Error on linker script generation: section '{entry.section_order_type}' not found.\n  Make sure the section '{entry.section_order_type}' is listed on 'section_order' of the yaml options."
+                    )
                 section_entries[entry.section_order_type].append(entry)
             elif prev_entry is not None:
                 # If this section is not present in section_order or section_order then pretend it is part of the last seen section, mainly for handling linker_offset
                 if prev_entry not in section_entries:
-                    log.error(f"Error on linker script generation: section '{prev_entry}' not found.\n  Make sure the section '{prev_entry}' is listed on 'section_order' of the yaml options.")
+                    log.error(
+                        f"Error on linker script generation: section '{prev_entry}' not found.\n  Make sure the section '{prev_entry}' is listed on 'section_order' of the yaml options."
+                    )
                 section_entries[prev_entry].append(entry)
             prev_entry = entry.section_order_type
 

--- a/src/splat/segtypes/linker_entry.py
+++ b/src/splat/segtypes/linker_entry.py
@@ -236,7 +236,7 @@ class LinkerWriter:
 
         section_entries: OrderedDict[str, List[LinkerEntry]] = OrderedDict()
         for l in segment.section_order:
-            if l in options.opts.ld_section_labels:
+            if l in options.opts.section_order:
                 section_entries[l] = []
 
         # Add all entries to section_entries
@@ -244,7 +244,7 @@ class LinkerWriter:
         for entry in entries:
             if entry.section_order_type in section_entries:
                 # Search for the very first section type
-                # This is required in case the very first entry is a type that's not listed on ld_section_labels (like linker_offset) because it would be dropped
+                # This is required in case the very first entry is a type that's not listed on section_order (like linker_offset) because it would be dropped
                 prev_entry = entry.section_order_type
                 break
 
@@ -254,7 +254,7 @@ class LinkerWriter:
             if entry.section_order_type in section_entries:
                 section_entries[entry.section_order_type].append(entry)
             elif prev_entry is not None:
-                # If this section is not present in section_order or ld_section_labels then pretend it is part of the last seen section, mainly for handling linker_offset
+                # If this section is not present in section_order or section_order then pretend it is part of the last seen section, mainly for handling linker_offset
                 section_entries[prev_entry].append(entry)
             any_load = any_load or not entry.noload
             any_noload = any_noload or entry.noload
@@ -285,14 +285,14 @@ class LinkerWriter:
 
         # To keep track which sections has been started
         started_sections: Dict[str, bool] = {
-            l: False for l in options.opts.ld_section_labels
+            l: False for l in options.opts.section_order
         }
 
         # Find where sections are last seen
         last_seen_sections: Dict[LinkerEntry, str] = {}
         for entry in reversed(entries):
             if (
-                entry.section_order_type in options.opts.ld_section_labels
+                entry.section_order_type in options.opts.section_order
                 and entry.section_order_type not in last_seen_sections.values()
             ):
                 last_seen_sections[entry] = entry.section_order_type
@@ -362,7 +362,7 @@ class LinkerWriter:
             self._begin_segment(segment, seg_name, noload=False, is_first=is_first)
 
             for l in segment.section_order:
-                if l not in options.opts.ld_section_labels:
+                if l not in options.opts.section_order:
                     continue
                 if l == ".bss":
                     continue
@@ -412,7 +412,7 @@ class LinkerWriter:
 
         section_entries: OrderedDict[str, List[LinkerEntry]] = OrderedDict()
         for l in segment.section_order:
-            if l in options.opts.ld_section_labels:
+            if l in options.opts.section_order:
                 section_entries[l] = []
 
         # Add all entries to section_entries
@@ -421,7 +421,7 @@ class LinkerWriter:
             if entry.section_order_type in section_entries:
                 section_entries[entry.section_order_type].append(entry)
             elif prev_entry is not None:
-                # If this section is not present in section_order or ld_section_labels then pretend it is part of the last seen section, mainly for handling linker_offset
+                # If this section is not present in section_order or section_order then pretend it is part of the last seen section, mainly for handling linker_offset
                 section_entries[prev_entry].append(entry)
             prev_entry = entry.section_order_type
 

--- a/src/splat/util/options.py
+++ b/src/splat/util/options.py
@@ -105,8 +105,6 @@ class SplatOpts:
     ld_sections_allowlist: List[str]
     # A list of sections to discard during link time. It can be useful to avoid using the wildcard discard. Note that this option does not turn off `ld_discard_section`
     ld_sections_denylist: List[str]
-    # Determines the list of section labels that are to be added to the linker script
-    ld_section_labels: List[str]
     # Determines whether to add wildcards for section linking in the linker script (.rodata* for example)
     ld_wildcard_sections: bool
     # Determines whether to use `follows_vram` (segment option) and
@@ -428,11 +426,6 @@ def _parse_yaml(
         ld_discard_section=p.parse_opt("ld_discard_section", bool, True),
         ld_sections_allowlist=p.parse_opt("ld_sections_allowlist", list, []),
         ld_sections_denylist=p.parse_opt("ld_sections_denylist", list, []),
-        ld_section_labels=p.parse_opt(
-            "ld_section_labels",
-            list,
-            [".text", ".data", ".rodata", ".bss"],
-        ),
         ld_wildcard_sections=p.parse_opt("ld_wildcard_sections", bool, False),
         ld_use_symbolic_vram_addresses=p.parse_opt(
             "ld_use_symbolic_vram_addresses", bool, True


### PR DESCRIPTION
`ld_section_labels` was redundant so lets just remove it.

I also added an error message to the linker script generator in case a section is missing from the `section_order`. It looks like this
```
Linker script main:   0%|                                                  | 0/5 [00:00<?, ?it/s]
Error on linker script generation: section '.vutext' not found.
  Make sure the section '.vutext' is listed on 'section_order' of the yaml options.
```