### PR TITLE
Add `EEGCC` compiler option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # splat Release Notes
 
+### 0.23.1
+
+* New `EEGCC` compiler option.
+  * Provide specific adjustments for the GCC compiler used for the PS2 platform.
+* `spimdisasm` 1.24.1 or above is now required.
+
 ### 0.23.0
 
 * splat now checks if symbol names can be valid filepaths and produce an error if not.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The brackets corresponds to the optional dependencies to install while installin
 If you use a `requirements.txt` file in your repository, then you can add this library with the following line:
 
 ```txt
-splat64[mips]>=0.23.0,<1.0.0
+splat64[mips]>=0.23.1,<1.0.0
 ```
 
 ### Optional dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.23.0"
+version = "0.23.1"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -20,7 +20,7 @@ dependencies = [
 
 [project.optional-dependencies]
 mips = [
-    "spimdisasm>=1.23.0,<2.0.0", # This value should be keep in sync with the version listed on disassembler/spimdisasm_disassembler.py
+    "spimdisasm>=1.24.1,<2.0.0", # This value should be keep in sync with the version listed on disassembler/spimdisasm_disassembler.py
     "rabbitizer>=1.8.0,<2.0.0",
     "pygfxd",
     "n64img>=0.1.4",

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -3,7 +3,7 @@ from typing import Tuple
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version__ = "0.23.0"
+__version__ = "0.24.1"
 __author__ = "ethteck"
 
 from . import util as util

--- a/src/splat/disassembler/spimdisasm_disassembler.py
+++ b/src/splat/disassembler/spimdisasm_disassembler.py
@@ -71,6 +71,8 @@ class SpimdisasmDisassembler(disassembler.Disassembler):
             spimdisasm.common.GlobalConfig.COMPILER = spimdisasm.common.Compiler.GCC
         elif selected_compiler == compiler.IDO:
             spimdisasm.common.GlobalConfig.COMPILER = spimdisasm.common.Compiler.IDO
+        elif selected_compiler == compiler.EEGCC:
+            spimdisasm.common.GlobalConfig.COMPILER = spimdisasm.common.Compiler.EEGCC
 
         spimdisasm.common.GlobalConfig.DETECT_REDUNDANT_FUNCTION_END = (
             options.opts.detect_redundant_function_end

--- a/src/splat/segtypes/common/c.py
+++ b/src/splat/segtypes/common/c.py
@@ -7,7 +7,7 @@ import rabbitizer
 import spimdisasm
 
 from ...util import log, options, symbols
-from ...util.compiler import GCC, SN64, IDO
+from ...util.compiler import IDO
 from ...util.symbols import Symbol
 
 from .codesubsegment import CommonSegCodeSubsegment
@@ -105,19 +105,19 @@ class CommonSegC(CommonSegCodeSubsegment):
     def get_global_asm_funcs(c_file: Path) -> Set[str]:
         with c_file.open() as f:
             text = CommonSegC.strip_c_comments(f.read())
-        if options.opts.compiler in [GCC, SN64]:
-            return set(CommonSegC.find_include_asm(text))
-        else:
+        if options.opts.compiler == IDO:
             return set(m.group(2) for m in C_GLOBAL_ASM_IDO_RE.finditer(text))
+        else:
+            return set(CommonSegC.find_include_asm(text))
 
     @staticmethod
     def get_global_asm_rodata_syms(c_file: Path) -> Set[str]:
         with c_file.open() as f:
             text = CommonSegC.strip_c_comments(f.read())
-        if options.opts.compiler in [GCC, SN64]:
-            return set(CommonSegC.find_include_rodata(text))
-        else:
+        if options.opts.compiler == IDO:
             return set(m.group(2) for m in C_GLOBAL_ASM_IDO_RE.finditer(text))
+        else:
+            return set(CommonSegC.find_include_rodata(text))
 
     @staticmethod
     def is_text() -> bool:

--- a/src/splat/util/compiler.py
+++ b/src/splat/util/compiler.py
@@ -34,7 +34,9 @@ SN64 = Compiler(
 
 IDO = Compiler("IDO", include_macro_inc=False, asm_emit_size_directive=False)
 
-compiler_for_name = {"GCC": GCC, "SN64": SN64, "IDO": IDO}
+EEGCC = Compiler("EEGCC")
+
+compiler_for_name = {"GCC": GCC, "SN64": SN64, "IDO": IDO, "EEGCC": EEGCC}
 
 
 def for_name(name: str) -> Compiler:


### PR DESCRIPTION
Mainly to tell spimdisasm to use the alignment directives on strings and functions 