### PR TITLE
Psp fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # splat Release Notes
 
+### 0.24.1
+
+* Tweak the disassembler's configuration for PSP platform to improve assembly analysis.
+  * Should improve function start/end detection.
+
 ### 0.24.0
 
 * Added PSP as a new platform.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The brackets corresponds to the optional dependencies to install while installin
 If you use a `requirements.txt` file in your repository, then you can add this library with the following line:
 
 ```txt
-splat64[mips]>=0.24.0,<1.0.0
+splat64[mips]>=0.24.1,<1.0.0
 ```
 
 ### Optional dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.24.0"
+version = "0.24.1"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -3,7 +3,7 @@ from typing import Tuple
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version__ = "0.24.0"
+__version__ = "0.24.1"
 __author__ = "ethteck"
 
 from . import util as util

--- a/src/splat/platforms/psp.py
+++ b/src/splat/platforms/psp.py
@@ -1,4 +1,5 @@
 import rabbitizer
 
+
 def init(target_bytes: bytes):
     rabbitizer.config.toolchainTweaks_treatJAsUnconditionalBranch = False

--- a/src/splat/platforms/psp.py
+++ b/src/splat/platforms/psp.py
@@ -1,2 +1,4 @@
+import rabbitizer
+
 def init(target_bytes: bytes):
-    pass
+    rabbitizer.config.toolchainTweaks_treatJAsUnconditionalBranch = False


### PR DESCRIPTION
PSP compilers seem to emit `j` as function calls instead of just a `b` replacement. This can mess with spimdisasm's analysis because the default configuration was to treat those two instructions the same.