### PR TITLE
Add `matchings_path` option to be used alongside `disassemble_all`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # splat Release Notes
 
+### 0.24.4
+
+* New yaml option: `matchings_path`
+  * Determines the path to the asm matchings directory
+  * This is used alongside `disassemble_all` to organize matching functions from nonmatching functions
+
 ### 0.24.3
 
 * New yaml option: `ld_align_segment_start`

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The brackets corresponds to the optional dependencies to install while installin
 If you use a `requirements.txt` file in your repository, then you can add this library with the following line:
 
 ```txt
-splat64[mips]>=0.24.3,<1.0.0
+splat64[mips]>=0.24.4,<1.0.0
 ```
 
 ### Optional dependencies

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -216,6 +216,9 @@ Determines the path to the asm data directory
 
 Determines the path to the asm nonmatchings directory
 
+### matchings_path
+
+Determines the path to the asm matchings directory (used alongside `disassemble_all` to organize matching functions from nonmatching functions)
 
 ### cache_path
 Path to splat cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.24.3"
+version = "0.24.4"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -3,7 +3,7 @@ from typing import Tuple
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version__ = "0.24.3"
+__version__ = "0.24.4"
 __author__ = "ethteck"
 
 from . import util as util

--- a/src/splat/segtypes/common/c.py
+++ b/src/splat/segtypes/common/c.py
@@ -228,10 +228,15 @@ class CommonSegC(CommonSegCodeSubsegment):
                         )
                         assert func_sym is not None
 
-                        if entry.function.getName() in self.global_asm_funcs or is_new_c_file:
+                        if (
+                            entry.function.getName() in self.global_asm_funcs
+                            or is_new_c_file
+                        ):
                             self.create_c_asm_file(entry, asm_out_dir, func_sym)
                         else:
-                            self.create_c_asm_file(entry, matching_asm_out_dir, func_sym)
+                            self.create_c_asm_file(
+                                entry, matching_asm_out_dir, func_sym
+                            )
                 else:
                     for spim_rodata_sym in entry.rodataSyms:
                         if (

--- a/src/splat/segtypes/common/c.py
+++ b/src/splat/segtypes/common/c.py
@@ -229,14 +229,16 @@ class CommonSegC(CommonSegCodeSubsegment):
                         assert func_sym is not None
 
                         if (
-                            entry.function.getName() in self.global_asm_funcs
-                            or is_new_c_file
+                            not entry.function.getName() in self.global_asm_funcs
+                            and options.opts.disassemble_all
+                            and not is_new_c_file
                         ):
-                            self.create_c_asm_file(entry, asm_out_dir, func_sym)
-                        else:
                             self.create_c_asm_file(
                                 entry, matching_asm_out_dir, func_sym
                             )
+                        else:
+                            self.create_c_asm_file(entry, asm_out_dir, func_sym)
+
                 else:
                     for spim_rodata_sym in entry.rodataSyms:
                         if (

--- a/src/splat/segtypes/common/c.py
+++ b/src/splat/segtypes/common/c.py
@@ -151,7 +151,9 @@ class CommonSegC(CommonSegCodeSubsegment):
     def split(self, rom_bytes: bytes):
         if self.rom_start != self.rom_end:
             asm_out_dir = options.opts.nonmatchings_path / self.dir
+            matching_asm_out_dir = options.opts.matchings_path / self.dir
             asm_out_dir.mkdir(parents=True, exist_ok=True)
+            matching_asm_out_dir.mkdir(parents=True, exist_ok=True)
 
             self.print_file_boundaries()
 
@@ -226,7 +228,10 @@ class CommonSegC(CommonSegCodeSubsegment):
                         )
                         assert func_sym is not None
 
-                        self.create_c_asm_file(entry, asm_out_dir, func_sym)
+                        if entry.function.getName() in self.global_asm_funcs or is_new_c_file:
+                            self.create_c_asm_file(entry, asm_out_dir, func_sym)
+                        else:
+                            self.create_c_asm_file(entry, matching_asm_out_dir, func_sym)
                 else:
                     for spim_rodata_sym in entry.rodataSyms:
                         if (

--- a/src/splat/util/options.py
+++ b/src/splat/util/options.py
@@ -61,6 +61,8 @@ class SplatOpts:
     data_path: Path
     # Determines the path to the asm nonmatchings directory
     nonmatchings_path: Path
+    # Determines the path to the asm matchings directory (used alongside `disassemble_all` to organize matching functions from nonmatching functions)
+    matchings_path: Path
     # Determines the path to the cache file (used when supplied --use-cache via the CLI)
     cache_path: Path
     # Tells splat to consider `hasm` files to be relative to `src_path` instead of `asm_path`.
@@ -402,6 +404,7 @@ def _parse_yaml(
         asm_path=asm_path,
         data_path=p.parse_path(asm_path, "data_path", "data"),
         nonmatchings_path=p.parse_path(asm_path, "nonmatchings_path", "nonmatchings"),
+        matchings_path=p.parse_path(asm_path, "matchings_path", "matchings"),
         cache_path=p.parse_path(base_path, "cache_path", ".splache"),
         hasm_in_src_path=p.parse_opt("hasm_in_src_path", bool, False),
         create_undefined_funcs_auto=p.parse_opt(

--- a/test.py
+++ b/test.py
@@ -53,7 +53,7 @@ class Testing(unittest.TestCase):
         spimdisasm.common.GlobalConfig.ASM_GENERATED_BY = False
         main(["test/basic_app/splat.yaml"], None, False)
 
-        comparison = filecmp.dircmp("test/basic_app/split", "test/basic_app/expected")
+        comparison = filecmp.dircmp("test/basic_app/split", "test/basic_app/expected", [".gitkeep"])
 
         diff_files: List[Tuple[str, str, str]] = []
         self.get_diff_files(comparison, diff_files)

--- a/test.py
+++ b/test.py
@@ -53,7 +53,9 @@ class Testing(unittest.TestCase):
         spimdisasm.common.GlobalConfig.ASM_GENERATED_BY = False
         main(["test/basic_app/splat.yaml"], None, False)
 
-        comparison = filecmp.dircmp("test/basic_app/split", "test/basic_app/expected", [".gitkeep"])
+        comparison = filecmp.dircmp(
+            "test/basic_app/split", "test/basic_app/expected", [".gitkeep"]
+        )
 
         diff_files: List[Tuple[str, str, str]] = []
         self.get_diff_files(comparison, diff_files)


### PR DESCRIPTION
I found that `disassemble_all` was a great addition that made it pretty easy to quickly use or analyze the original assembly of an already matched function. That said, it splits the assembly for matching functions to the nonmatching path. While this isn't a big deal, I do think it is a determent to organization, and may possibly conflict with some makefiles or progress scripts which blindly scan the `nonmatching` folder.
This PR adds an option that works alongside `disassemble_all`, where if a function is a _global asm func_, and if `disassemble_all` is true, it will be split to the directory pointed to by a new variable `matchings_path`. I set the default value of this variable to `matchings`.
Besides being a solution to the problems I listed earlier, this might also have the benefit of giving the user more options to determine matching progress, and maybe more stuff I haven't considered.