### PR TITLE
Add Legacy of Kain: Soul Reaver to the PS1 Projects list

### DIFF
--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -25,6 +25,7 @@ The following is a list of projects known to be using **splat** along with the c
 
 - [Evo's Space Adventures](https://github.com/mkst/esa) `psyq 4.6 (gcc2.95)`
 - [Final Fantasy 7](https://github.com/Drahsid/ffvii) `psyq <= 4.1 (gcc2.7.2)`
+- [Legacy of Kain: Soul Reaver](https://github.com/FedericoMilesi/soul-re) `psyq 4.3 (gcc2.8.1)`
 - [Silent Hill](https://github.com/Vatuu/silent-hill-decomp) `psyq <= 4.1 (gcc2.7.2) TBD`
 
 ## PS2 Projects


### PR DESCRIPTION
Includes Legacy of Kain: Soul Reaver as an example of a PSX project that uses splat.