### PR TITLE
[WIP] Add settings to toggle `%gp_rel` usage on generated assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # splat Release Notes
 
+### 0.25.2
+
+* TODO
+
 ### 0.25.1
 
 * Added two new segment types: `gcc_except_table` and `eh_frame`.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The brackets corresponds to the optional dependencies to install while installin
 If you use a `requirements.txt` file in your repository, then you can add this library with the following line:
 
 ```txt
-splat64[mips]>=0.25.1,<1.0.0
+splat64[mips]>=0.25.2,<1.0.0
 ```
 
 ### Optional dependencies

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -635,6 +635,18 @@ Allow specifying that the global memory range may be larger than what was automa
 
 Useful for projects where splat is used in multiple individual files, meaning the expected global segment may not be properly detected because each instance of splat can't see the info from other files, like in PSX and PSP projects.
 
+### use_gp_rel_macro
+
+TODO
+
+Defaults to `True`
+
+### use_gp_rel_macro_nonmatching
+
+TODO
+
+Defaults to `True`
+
 ## N64-specific options
 
 ### header_encoding

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.25.1"
+version = "0.25.2"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -20,7 +20,7 @@ dependencies = [
 
 [project.optional-dependencies]
 mips = [
-    "spimdisasm>=1.27.0,<2.0.0", # This value should be keep in sync with the version listed on disassembler/spimdisasm_disassembler.py
+    "spimdisasm>=1.27.1,<2.0.0", # This value should be keep in sync with the version listed on disassembler/spimdisasm_disassembler.py
     "rabbitizer>=1.10.0,<2.0.0",
     "pygfxd",
     "n64img>=0.1.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ tqdm
 intervaltree
 colorama
 # This value should be keep in sync with the version listed on disassembler/spimdisasm_disassembler.py and pyproject.toml
-spimdisasm>=1.26.0
+spimdisasm>=1.27.1
 rabbitizer>=1.10.0
 pygfxd
 n64img>=0.1.4

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -3,7 +3,7 @@ from typing import Tuple
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version__ = "0.25.0"
+__version__ = "0.25.2"
 __author__ = "ethteck"
 
 from . import util as util

--- a/src/splat/disassembler/spimdisasm_disassembler.py
+++ b/src/splat/disassembler/spimdisasm_disassembler.py
@@ -7,7 +7,7 @@ from typing import Set
 
 class SpimdisasmDisassembler(disassembler.Disassembler):
     # This value should be kept in sync with the version listed on requirements.txt and pyproject.toml
-    SPIMDISASM_MIN = (1, 27, 0)
+    SPIMDISASM_MIN = (1, 27, 1)
 
     def configure(self):
         # Configure spimdisasm

--- a/src/splat/segtypes/common/c.py
+++ b/src/splat/segtypes/common/c.py
@@ -36,6 +36,8 @@ class CommonSegC(CommonSegCodeSubsegment):
 
         self.file_extension = "c"
 
+        self.use_gp_rel_macro = options.opts.use_gp_rel_macro_nonmatching
+
     @staticmethod
     def strip_c_comments(text):
         def replacer(match):

--- a/src/splat/segtypes/common/codesubsegment.py
+++ b/src/splat/segtypes/common/codesubsegment.py
@@ -41,6 +41,7 @@ class CommonSegCodeSubsegment(Segment):
         )
 
         self.is_hasm = False
+        self.use_gp_rel_macro = options.opts.use_gp_rel_macro
 
     @property
     def needs_symbols(self) -> bool:
@@ -59,6 +60,7 @@ class CommonSegCodeSubsegment(Segment):
         section.isHandwritten = self.is_hasm
         section.instrCat = self.instr_category
         section.detectRedundantFunctionEnd = self.detect_redundant_function_end
+        section.gpRelHack = not self.use_gp_rel_macro
 
     def scan_code(self, rom_bytes, is_hasm=False):
         self.is_hasm = is_hasm

--- a/src/splat/util/options.py
+++ b/src/splat/util/options.py
@@ -226,6 +226,10 @@ class SplatOpts:
     # Useful for projects where splat is used in multiple individual files, meaning the expected global segment may not be properly detected because each instance of splat can't see the info from other files.
     global_vram_start: Optional[int]
     global_vram_end: Optional[int]
+    # 
+    use_gp_rel_macro: bool
+    # 
+    use_gp_rel_macro_nonmatching: bool
 
     ################################################################################
     # N64-specific options
@@ -550,6 +554,8 @@ def _parse_yaml(
         ),
         global_vram_start=p.parse_optional_opt("global_vram_start", int),
         global_vram_end=p.parse_optional_opt("global_vram_end", int),
+        use_gp_rel_macro=p.parse_opt("use_gp_rel_macro", bool, True),
+        use_gp_rel_macro_nonmatching=p.parse_opt("use_gp_rel_macro_nonmatching", bool, True),
     )
     p.check_no_unread_opts()
     return ret


### PR DESCRIPTION
Fixes #391 

This is still a Work-In-Progress.

I'm opening this PR in the current state since I'm looking for people to actually test that this new feature is working properly.

To test this PR:
- Install / checkout this PR.
- Set `use_gp_rel_macro_nonmatching: False` on your yaml
- Install the development version of spimdisasm:
    ```
    python3 -m pip uninstall spimdisasm
    python3 -m pip install git+https://github.com/Decompollaborate/spimdisasm.git@develop
    ```
- Disable your own custom `%gp_rel` patching system.

If everything works as it should then running splat and then building your project should Just Work :tm:. Please let me know if it doesn't.
