### PR TITLE
Fix some `rdata` issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 ### 0.26.1
 
 * Fix pairing text to other sections on cases where text is not be the first section.
+* Fix some code that assumes that `.rodata` will always be present on the `sections_order` list.
 * Fix `.text`/`.rdata` section pairing (hopefully).
+* Emit an error if we try to migrate the rodata symbols to functions if the rodata section is not prefixed with a dot (ie `- [0x1234, rodata, some_file]` instead of `- [0x1234, .rodata, some_file]`)
+  * Not prefixing the type with a dot would produce splat to both disassemble the rodata section to its own assembly file and to migrate the symbols to the corresponding functions, generating link-time errors and many headaches.
+* Rewrite the `ld_legacy_generation` docs for clarity.
 
 ### 0.26.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # splat Release Notes
 
+### 0.26.1
+
+* Fix pairing text to other sections on cases where text is not be the first section.
+
 ### 0.26.0
 
 * Fixed the `subalign` segment property logic to be more straightforward

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 0.26.1
 
 * Fix pairing text to other sections on cases where text is not be the first section.
+* Fix `.text`/`.rdata` section pairing (hopefully).
 
 ### 0.26.0
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The brackets corresponds to the optional dependencies to install while installin
 If you use a `requirements.txt` file in your repository, then you can add this library with the following line:
 
 ```txt
-splat64[mips]>=0.26.0,<1.0.0
+splat64[mips]>=0.26.1,<1.0.0
 ```
 
 ### Optional dependencies

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -400,7 +400,11 @@ Generate a dependency file for every linker script generated. Dependency files w
 
 ### ld_legacy_generation
 
-Legacy linker script generation does not impose the section_order specified in the yaml options or per-segment options.
+Currently splat imposes the given `section_order` when generating the linker script. But in some cases it may not be desirable to impose the section ordering because the ROM itself may not follow a logical section ordering.
+
+To disable this behavior then turn on the `ld_legacy_generation` option. This way splat will blindly follow the yaml order, allowing to interleave unrelated sections. This setting must be treated as a last resort, since most ROMs do follow a logical ordering. If some specific files have weird ordering on one of their sections then it is recommended to use the [`linker_section_order`](Segments.md#linker_section_order) attribute of a given file entry instead.
+
+This option defaults to `False`.
 
 ### segment_end_before_align
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.26.0"
+version = "0.26.1"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -1,7 +1,7 @@
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version__ = "0.26.0"
+__version__ = "0.26.1"
 __author__ = "ethteck"
 
 from . import util as util

--- a/src/splat/segtypes/common/c.py
+++ b/src/splat/segtypes/common/c.py
@@ -171,21 +171,23 @@ class CommonSegC(CommonSegCodeSubsegment):
                     if rodata_sibling is None:
                         continue
 
+                    if rodata_sibling.is_auto_all:
+                        continue
+
                     assert isinstance(
                         rodata_sibling, CommonSegRodata
-                    ), rodata_sibling.type
+                    ), f"{rodata_sibling}, {rodata_sibling.type}"
 
                     rodata_section_type = (
                         rodata_sibling.get_linker_section_linksection()
                     )
 
-                    # rodata_sibling.spim_section may be None if said sibling is an auto inserted one
-                    if rodata_sibling.spim_section is not None:
-                        assert isinstance(
-                            rodata_sibling.spim_section.get_section(),
-                            spimdisasm.mips.sections.SectionRodata,
-                        )
-                        rodata_spim_segment = rodata_sibling.spim_section.get_section()
+                    assert rodata_sibling.spim_section is not None, f"{rodata_sibling}"
+                    assert isinstance(
+                        rodata_sibling.spim_section.get_section(),
+                        spimdisasm.mips.sections.SectionRodata,
+                    )
+                    rodata_spim_segment = rodata_sibling.spim_section.get_section()
 
                     # Stop searching
                     break

--- a/src/splat/segtypes/common/c.py
+++ b/src/splat/segtypes/common/c.py
@@ -179,12 +179,16 @@ class CommonSegC(CommonSegCodeSubsegment):
                     ), f"{rodata_sibling}, {rodata_sibling.type}"
 
                     if not rodata_sibling.type.startswith("."):
+                        # Emit an error if we try to migrate the rodata symbols to functions if the rodata section is not prefixed with a dot
+                        # (ie `- [0x1234, rodata, some_file]` instead of `- [0x1234, .rodata, some_file]`).
+                        # Not prefixing the type with a dot would produce splat to both disassemble the rodata section to its own assembly file
+                        # and to migrate the symbols to the corresponding functions, generating link-time errors and many headaches.
                         log.write(
                             f"\nProblem detected with the `{rodata_sibling.type}` section of the `{rodata_sibling.name}` file during rodata migration.",
                             status="warn",
                         )
                         log.write(
-                            f"\t Since the `{rodata_sibling.type}` section was not prefixed with a dot, then it will be both disassembled to its own assembly file and it the contents will be migrated to the `{self.file_extension}` file, which will produce link-time errors."
+                            f"\t The `{rodata_sibling.type}` section was not prefixed with a dot, which is required for the rodata migration feature to work properly and avoid build errors due to duplicated symbols at link-time."
                         )
                         log.error(
                             f"\t To fix this, please prefix the section type with a dot (like `.{rodata_sibling.type}`)."

--- a/src/splat/segtypes/common/c.py
+++ b/src/splat/segtypes/common/c.py
@@ -178,6 +178,18 @@ class CommonSegC(CommonSegCodeSubsegment):
                         rodata_sibling, CommonSegRodata
                     ), f"{rodata_sibling}, {rodata_sibling.type}"
 
+                    if not rodata_sibling.type.startswith("."):
+                        log.write(
+                            f"\nProblem detected with the `{rodata_sibling.type}` section of the `{rodata_sibling.name}` file during rodata migration.",
+                            status="warn",
+                        )
+                        log.write(
+                            f"\t Since the `{rodata_sibling.type}` section was not prefixed with a dot, then it will be both disassembled to its own assembly file and it the contents will be migrated to the `{self.file_extension}` file, which will produce link-time errors."
+                        )
+                        log.error(
+                            f"\t To fix this, please prefix the section type with a dot (like `.{rodata_sibling.type}`)."
+                        )
+
                     rodata_section_type = (
                         rodata_sibling.get_linker_section_linksection()
                     )

--- a/src/splat/util/__init__.py
+++ b/src/splat/util/__init__.py
@@ -10,4 +10,5 @@ from . import psx as psx
 from . import relocs as relocs
 from . import statistics as statistics
 from . import symbols as symbols
+from . import utils as utils
 from . import vram_classes as vram_classes

--- a/src/splat/util/utils.py
+++ b/src/splat/util/utils.py
@@ -2,6 +2,7 @@ from typing import List, Optional, TypeVar
 
 T = TypeVar("T")
 
+
 def list_index(l: List[T], value: T) -> Optional[int]:
     if value not in l:
         return None

--- a/src/splat/util/utils.py
+++ b/src/splat/util/utils.py
@@ -1,0 +1,8 @@
+from typing import List, Optional, TypeVar
+
+T = TypeVar("T")
+
+def list_index(l: List[T], value: T) -> Optional[int]:
+    if value not in l:
+        return None
+    return l.index(value)


### PR DESCRIPTION
- Fix pairing text to other sections on cases where text is not be the first section.
- Fix some code that assumes that `.rodata` will always be present on the `sections_order` list.
- Fix `.text`/`.rdata` section pairing (hopefully).
- Emit an error if we try to migrate the rodata symbols to functions if the rodata section is not prefixed with a dot (ie `- [0x1234, rodata, some_file]` instead of `- [0x1234, .rodata, some_file]`)
  - Not prefixing the type with a dot would produce splat to both disassemble the rodata section to its own assembly file and to migrate the symbols to the corresponding functions, generating link-time errors and many headaches.
- Rewrite the `ld_legacy_generation` docs for clarity.
