### PR TITLE
Fix not being able to disable `SUBALIGN` on the segment level and remove bugged image alignment check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ### 0.26.2
 
-Nothing yet c:
-
+* Fixed not being able to disable the `subalign` directive for a given segment.
+* Removed bugged alignment check on image segments.
+* splat will now error out if any of the following attributes is specified in a non top-level segment.
+  * `subalign`
+  * `ld_fill_value`.
 * `spimdisasm` 1.28.1 or above is now required.
 
 ### 0.26.1

--- a/src/splat/scripts/split.py
+++ b/src/splat/scripts/split.py
@@ -74,7 +74,7 @@ def initialize_segments(config_segments: Union[dict, list]) -> List[Segment]:
             next_start = last_rom_end
 
         segment: Segment = Segment.from_yaml(
-            segment_class, seg_yaml, this_start, next_start
+            segment_class, seg_yaml, this_start, next_start, True
         )
 
         if segment.require_unique_name:

--- a/src/splat/scripts/split.py
+++ b/src/splat/scripts/split.py
@@ -74,7 +74,7 @@ def initialize_segments(config_segments: Union[dict, list]) -> List[Segment]:
             next_start = last_rom_end
 
         segment: Segment = Segment.from_yaml(
-            segment_class, seg_yaml, this_start, next_start, True
+            segment_class, seg_yaml, this_start, next_start, None
         )
 
         if segment.require_unique_name:

--- a/src/splat/segtypes/common/code.py
+++ b/src/splat/segtypes/common/code.py
@@ -219,7 +219,7 @@ class CommonSegCode(CommonSegGroup):
                 end = last_rom_end
 
             segment: Segment = Segment.from_yaml(
-                segment_class, subsegment_yaml, start, end, False, vram
+                segment_class, subsegment_yaml, start, end, self, vram
             )
 
             if (
@@ -241,7 +241,6 @@ class CommonSegCode(CommonSegGroup):
                 if segment.is_rodata() and segment.sibling is None:
                     base_segments[segment.name] = segment
 
-            segment.parent = self
             if segment.special_vram_segment:
                 self.special_vram_segment = True
 

--- a/src/splat/segtypes/common/code.py
+++ b/src/splat/segtypes/common/code.py
@@ -219,7 +219,7 @@ class CommonSegCode(CommonSegGroup):
                 end = last_rom_end
 
             segment: Segment = Segment.from_yaml(
-                segment_class, subsegment_yaml, start, end, vram
+                segment_class, subsegment_yaml, start, end, False, vram
             )
 
             if (

--- a/src/splat/segtypes/common/group.py
+++ b/src/splat/segtypes/common/group.py
@@ -102,7 +102,7 @@ class CommonSegGroup(CommonSegment):
                 end = last_rom_end
 
             segment: Segment = Segment.from_yaml(
-                segment_class, subsegment_yaml, start, end, vram
+                segment_class, subsegment_yaml, start, end, False, vram
             )
             segment.parent = self
             if segment.special_vram_segment:

--- a/src/splat/segtypes/common/group.py
+++ b/src/splat/segtypes/common/group.py
@@ -102,9 +102,8 @@ class CommonSegGroup(CommonSegment):
                 end = last_rom_end
 
             segment: Segment = Segment.from_yaml(
-                segment_class, subsegment_yaml, start, end, False, vram
+                segment_class, subsegment_yaml, start, end, self, vram
             )
-            segment.parent = self
             if segment.special_vram_segment:
                 self.special_vram_segment = True
 

--- a/src/splat/segtypes/n64/img.py
+++ b/src/splat/segtypes/n64/img.py
@@ -58,10 +58,9 @@ class N64SegImg(N64Segment):
         expected_len = int(self.n64img.size())
         assert isinstance(self.rom_start, int)
         assert isinstance(self.rom_end, int)
-        assert isinstance(self.subalign, int)
 
         actual_len = self.rom_end - self.rom_start
-        if actual_len > expected_len and actual_len - expected_len > self.subalign:
+        if actual_len > expected_len:
             log.error(
                 f"Error: {self.name} should end at 0x{self.rom_start + expected_len:X}, but it ends at 0x{self.rom_end:X}\n(hint: add a 'bin' segment after it)"
             )

--- a/src/splat/segtypes/segment.py
+++ b/src/splat/segtypes/segment.py
@@ -313,6 +313,7 @@ class Segment:
         yaml: Union[dict, list],
         rom_start: Optional[int],
         rom_end: Optional[int],
+        is_toplevel: bool,
         vram=None,
     ):
         type = Segment.parse_segment_type(yaml)
@@ -339,6 +340,9 @@ class Segment:
             yaml=yaml,
         )
         ret.given_section_order = parse_segment_section_order(yaml)
+        if not is_toplevel:
+            if "subalign" in yaml:
+                log.error(f"Non top-level segment '{name}' (rom address 0x{rom_start:X}) specified a `subalign`. `subalign` is valid only for top-level segments")
         ret.given_subalign = parse_segment_subalign(yaml)
 
         if isinstance(yaml, dict):

--- a/src/splat/segtypes/segment.py
+++ b/src/splat/segtypes/segment.py
@@ -313,7 +313,7 @@ class Segment:
         yaml: Union[dict, list],
         rom_start: Optional[int],
         rom_end: Optional[int],
-        is_toplevel: bool,
+        parent: Optional["Segment"],
         vram=None,
     ):
         type = Segment.parse_segment_type(yaml)
@@ -339,7 +339,7 @@ class Segment:
             args=args,
             yaml=yaml,
         )
-        if not is_toplevel:
+        if parent is not None:
             if "subalign" in yaml:
                 log.error(
                     f"Non top-level segment '{name}' (rom address 0x{rom_start:X}) specified a `subalign`. `subalign` is valid only for top-level segments"
@@ -348,6 +348,8 @@ class Segment:
                 log.error(
                     f"Non top-level segment '{name}' (rom address 0x{rom_start:X}) specified a `ld_fill_value`. `ld_fill_value` is valid only for top-level segments"
                 )
+
+        ret.parent = parent
 
         ret.given_section_order = parse_segment_section_order(yaml)
         ret.given_subalign = parse_segment_subalign(yaml)

--- a/src/splat/segtypes/segment.py
+++ b/src/splat/segtypes/segment.py
@@ -341,9 +341,13 @@ class Segment:
         )
         if not is_toplevel:
             if "subalign" in yaml:
-                log.error(f"Non top-level segment '{name}' (rom address 0x{rom_start:X}) specified a `subalign`. `subalign` is valid only for top-level segments")
+                log.error(
+                    f"Non top-level segment '{name}' (rom address 0x{rom_start:X}) specified a `subalign`. `subalign` is valid only for top-level segments"
+                )
             if "ld_fill_value" in yaml:
-                log.error(f"Non top-level segment '{name}' (rom address 0x{rom_start:X}) specified a `ld_fill_value`. `ld_fill_value` is valid only for top-level segments")
+                log.error(
+                    f"Non top-level segment '{name}' (rom address 0x{rom_start:X}) specified a `ld_fill_value`. `ld_fill_value` is valid only for top-level segments"
+                )
 
         ret.given_section_order = parse_segment_section_order(yaml)
         ret.given_subalign = parse_segment_subalign(yaml)

--- a/src/splat/segtypes/segment.py
+++ b/src/splat/segtypes/segment.py
@@ -339,10 +339,13 @@ class Segment:
             args=args,
             yaml=yaml,
         )
-        ret.given_section_order = parse_segment_section_order(yaml)
         if not is_toplevel:
             if "subalign" in yaml:
                 log.error(f"Non top-level segment '{name}' (rom address 0x{rom_start:X}) specified a `subalign`. `subalign` is valid only for top-level segments")
+            if "ld_fill_value" in yaml:
+                log.error(f"Non top-level segment '{name}' (rom address 0x{rom_start:X}) specified a `ld_fill_value`. `ld_fill_value` is valid only for top-level segments")
+
+        ret.given_section_order = parse_segment_section_order(yaml)
         ret.given_subalign = parse_segment_subalign(yaml)
 
         if isinstance(yaml, dict):

--- a/src/splat/segtypes/segment.py
+++ b/src/splat/segtypes/segment.py
@@ -51,13 +51,13 @@ def parse_segment_align(segment: Union[dict, list]) -> Optional[int]:
 
 
 def parse_segment_subalign(segment: Union[dict, list]) -> Optional[int]:
+    default = options.opts.subalign
     if isinstance(segment, dict):
-        subalign = segment.get("subalign")
+        subalign = segment.get("subalign", default)
         if subalign != None:
-            assert isinstance(subalign, int)
             subalign = int(subalign)
         return subalign
-    return None
+    return default
 
 
 def parse_segment_section_order(segment: Union[dict, list]) -> List[str]:
@@ -237,7 +237,7 @@ class Segment:
         self.vram_start: Optional[int] = vram_start
 
         self.align: Optional[int] = None
-        self.given_subalign: Optional[int] = None
+        self.given_subalign: Optional[int] = options.opts.subalign
         self.exclusive_ram_id: Optional[str] = None
         self.given_dir: Path = Path()
 
@@ -433,12 +433,10 @@ class Segment:
 
     @property
     def subalign(self) -> Optional[int]:
-        if self.given_subalign is not None:
-            return self.given_subalign
-        elif self.parent:
+        if self.parent:
             return self.parent.subalign
         else:
-            return options.opts.subalign
+            return self.given_subalign
 
     @property
     def vram_symbol(self) -> Optional[str]:


### PR DESCRIPTION
* Fixed not being able to disable the `subalign` directive for a given segment.
* Removed bugged alignment check on image segments.
* splat will now error out if any of the following attributes is specified in a non top-level segment.
  * `subalign`
  * `ld_fill_value`.