### PR TITLE
Fix crash on zero-sized segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # splat Release Notes
 
+### 0.28.1
+
+* Fix a crash when listing zero-sized segments on the yaml.
+  * It is discouraged to have zero sized segments on the yaml, but they may be needed on games that have a "segment address" table of any kind and shows the segments having a zero size.
+  * This allows to have segment symbols for those kind of segments without having to go through linker script hacks.
+
 ### 0.28.0
+
 * Minor version release for previous release's breaking change that should have had its own minor release (oopsh, yanked 0.27.4)
 * BREKAING: Change the default value for `ld_generate_symbol_per_data_segment`. It defaults to `False` now.
 * Improve `create_config` to avoid choking on SN64 games.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The brackets corresponds to the optional dependencies to install while installin
 If you use a `requirements.txt` file in your repository, then you can add this library with the following line:
 
 ```txt
-splat64[mips]>=0.28.0,<1.0.0
+splat64[mips]>=0.28.1,<1.0.0
 ```
 
 ### Optional dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.28.0"
+version = "0.28.1-dev0"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.28.1-dev0"
+version = "0.28.1"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -1,7 +1,7 @@
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version__ = "0.28.0"
+__version__ = "0.28.1-dev0"
 __author__ = "ethteck"
 
 from . import util as util

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -1,7 +1,7 @@
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version__ = "0.28.1-dev0"
+__version__ = "0.28.1"
 __author__ = "ethteck"
 
 from . import util as util

--- a/src/splat/util/symbols.py
+++ b/src/splat/util/symbols.py
@@ -374,7 +374,9 @@ def initialize_spim_context(all_segments: "List[Segment]") -> None:
             elif global_vrom_end < segment.rom_end:
                 global_vrom_end = segment.rom_end
 
-        else:
+        elif segment.vram_start != segment.vram_end:
+            # Do not tell to spimdisasm about zero-sized segments.
+
             spim_segment = spim_context.addOverlaySegment(
                 ram_id,
                 segment.rom_start,


### PR DESCRIPTION
spimdisasm crashes on an `assert` if you try to pass it a zero sized overlay, since it would throw off its per-segment analysis.

So this fixes this issue on splat's side because of the linker script generator.
