### PR TITLE
Tag `PSYQ` as a compiler that uses `j` instructions as branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # splat Release Notes
 
+### 0.31.1
+
+* Tag `PSYQ` as a compiler that uses `j` instructions as branches.
+  * Fixes incorrect detection of non existing functions under the mentioned compiler.
+
 ### 0.31.0
 
 * Fix subsegments of auto `data` segments not being split.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The brackets corresponds to the optional dependencies to install while installin
 If you use a `requirements.txt` file in your repository, then you can add this library with the following line:
 
 ```txt
-splat64[mips]>=0.31.0,<1.0.0
+splat64[mips]>=0.31.1,<1.0.0
 ```
 
 ### Optional dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.31.0"
+version = "0.31.1-dev0"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.31.1-dev0"
+version = "0.31.1"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -1,7 +1,7 @@
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version__ = "0.31.0"
+__version__ = "0.31.1-dev0"
 __author__ = "ethteck"
 
 from . import util as util

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -1,7 +1,7 @@
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version__ = "0.31.1-dev0"
+__version__ = "0.31.1"
 __author__ = "ethteck"
 
 from . import util as util

--- a/src/splat/util/compiler.py
+++ b/src/splat/util/compiler.py
@@ -48,7 +48,10 @@ EGCS = Compiler(
 )
 
 # PS1
-PSYQ = Compiler("PSYQ")
+PSYQ = Compiler(
+    "PSYQ",
+    j_as_branch=True,
+)
 
 # PS2
 MWCCPS2 = Compiler("MWCCPS2")


### PR DESCRIPTION
Fixes incorrect detection of non existing functions
