### PR TITLE
Include subsegment information when aggregating split statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # splat Release Notes
 
+### 0.32.1
+* Include subsegment information when aggregating split statistics.
+
 ### 0.32.0
 
 * Tag `PSYQ` as a compiler that uses `j` instructions as branches.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,5 +46,8 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/splat"]
 
+[tool.hatch.envs.dev]
+features = ["dev"]
+
 [project.scripts]
 splat = "splat.__main__:splat_main"

--- a/src/splat/scripts/split.py
+++ b/src/splat/scripts/split.py
@@ -271,11 +271,9 @@ def do_scan(
     for segment in scan_bar:
         assert isinstance(segment, Segment)
         scan_bar.set_description(f"Scanning {brief_seg_name(segment, 20)}")
-        typ = segment.type
-        if segment.type == "bin" and segment.is_name_default():
-            typ = "unk"
 
-        stats.add_size(typ, segment.size)
+        for ty, sub_stats in segment.statistics.items():
+            stats.add_size(ty, sub_stats.size)
 
         if segment.should_scan():
             # Check cache but don't write anything
@@ -287,7 +285,8 @@ def do_scan(
 
             processed_segments.append(segment)
 
-            stats.count_split(typ)
+            for ty, sub_stats in segment.statistics.items():
+                stats.count_split(ty, sub_stats.count)
 
     symbols.mark_c_funcs_as_defined()
     return processed_segments
@@ -305,7 +304,8 @@ def do_split(
         split_bar.set_description(f"Splitting {brief_seg_name(segment, 20)}")
 
         if cache.check_cache_hit(segment, True):
-            stats.count_cached(segment.type)
+            for ty, sub_stats in segment.statistics.items():
+                stats.count_cached(ty, sub_stats.count)
             continue
 
         if segment.should_split():

--- a/src/splat/segtypes/common/bin.py
+++ b/src/splat/segtypes/common/bin.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from ...util import log, options
 
-from .segment import CommonSegment
+from .segment import CommonSegment, SegmentType
 
 
 class CommonSegBin(CommonSegment):
@@ -33,3 +33,10 @@ class CommonSegBin(CommonSegment):
 
             f.write(rom_bytes[self.rom_start : self.rom_end])
         self.log(f"Wrote {self.name} to {path}")
+
+    @property
+    def statistics_type(self) -> SegmentType:
+        stats_type = self.type
+        if self.is_name_default():
+            stats_type = "unk"
+        return stats_type

--- a/src/splat/segtypes/common/group.py
+++ b/src/splat/segtypes/common/group.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 from ...util import log
 
 from .segment import CommonSegment
-from ..segment import Segment
+from ..segment import empty_statistics, Segment, SegmentStatistics
 
 
 class CommonSegGroup(CommonSegment):
@@ -123,6 +123,14 @@ class CommonSegGroup(CommonSegment):
             if seg.needs_symbols:
                 return True
         return False
+
+    @property
+    def statistics(self) -> SegmentStatistics:
+        stats = empty_statistics()
+        for sub in self.subsegments:
+            for ty, info in sub.statistics.items():
+                stats[ty] = stats[ty].merge(info)
+        return stats
 
     def get_linker_entries(self):
         return [entry for sub in self.subsegments for entry in sub.get_linker_entries()]

--- a/src/splat/segtypes/common/segment.py
+++ b/src/splat/segtypes/common/segment.py
@@ -1,4 +1,4 @@
-from ...segtypes.segment import Segment
+from ...segtypes.segment import Segment, SegmentType
 
 
 class CommonSegment(Segment):

--- a/src/splat/util/statistics.py
+++ b/src/splat/util/statistics.py
@@ -24,15 +24,15 @@ class Statistics:
             self.seg_sizes[typ] = 0
         self.seg_sizes[typ] += 0 if size is None else size
 
-    def count_split(self, typ: str):
+    def count_split(self, typ: str, count: int = 1):
         if typ not in self.seg_split:
             self.seg_split[typ] = 0
-        self.seg_split[typ] += 1
+        self.seg_split[typ] += count
 
-    def count_cached(self, typ: str):
+    def count_cached(self, typ: str, count: int = 1):
         if typ not in self.seg_cached:
             self.seg_cached[typ] = 0
-        self.seg_cached[typ] += 1
+        self.seg_cached[typ] += count
 
     def print_statistics(self, total_size: int):
         unk_size = self.seg_sizes.get("unk", 0)


### PR DESCRIPTION
Fixes #432 

### Description
Extend `util.Statistics` so that it breaks out statistics for segments which include subsegments.

I extended the base `Segment` type to include a property `statistics` for querying subsegment statistics, defaulting to the current segment information only. `CommonSegGroup` overrides this to provide aggregated statistics based on all of its subsegments.

### Caveat
This change has the effect that a segment inheriting from `CommonSegGroup` will not be itself included in the statistics output. An example is given in the test output below.

I'm not sure if this is desired behavior, but I couldn't figure out a way to incorporate both subsegment information and retain the segment name without changing the output into some kind of tree format. 

### Test output

Using the following segment configuration:

```yaml
segments:
  - [0x0, header]
  - type: code
    start: 0x800
    vram: 0x8002D000
    subsegments:
      - [0x800, bin]
      - [0x101f8, asm, a]
      - [0x102a8, bin]
      - [0x349a8, asm, b]
      - [0x349c8, bin]
      - [0x34b50, asm, c]
      - [0x34bd0, bin]
  - [0x80000]
```

Before:
```
Split 524 KB (100.00%) in defined segments
              header:     2 KB (0.39%) 1 split, 0 cached
                code:   522 KB (99.61%) 1 split, 0 cached
             unknown:      0 B (0.00%) from unknown bin files
```

After:
```
Split 2 KB (0.45%) in defined segments
              header:     2 KB (0.39%) 1 split, 0 cached
                 asm:    336 B (0.06%) 3 split, 0 cached
             unknown:   521 KB (99.55%) from unknown bin files
```
