### PR TITLE
Fix jtbl labels missing segment suffixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # splat Release Notes
 
+### 0.32.2
+
+* Fix jumptable labels not being properly formatted with the given `symbol_name_format`.
+* `spimdisasm` 1.32.0 or above is now required.
+
 ### 0.32.1
+
 * Include subsegment information when aggregating split statistics.
 
 ### 0.32.0

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The brackets corresponds to the optional dependencies to install while installin
 If you use a `requirements.txt` file in your repository, then you can add this library with the following line:
 
 ```txt
-splat64[mips]>=0.32.0,<1.0.0
+splat64[mips]>=0.32.2,<1.0.0
 ```
 
 ### Optional dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.32.0"
+version = "0.32.2"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -20,7 +20,7 @@ dependencies = [
 
 [project.optional-dependencies]
 mips = [
-    "spimdisasm>=1.31.0,<2.0.0", # This value should be keep in sync with the version listed on disassembler/spimdisasm_disassembler.py
+    "spimdisasm>=1.32.0,<2.0.0", # This value should be keep in sync with the version listed on disassembler/spimdisasm_disassembler.py
     "rabbitizer>=1.12.0,<2.0.0",
     "pygfxd",
     "n64img>=0.3.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ tqdm
 intervaltree
 colorama
 # This value should be keep in sync with the version listed on disassembler/spimdisasm_disassembler.py and pyproject.toml
-spimdisasm>=1.31.0
+spimdisasm>=1.32.0
 rabbitizer>=1.10.0
 pygfxd
 n64img>=0.1.4

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -1,7 +1,7 @@
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version__ = "0.32.0"
+__version__ = "0.32.2"
 __author__ = "ethteck"
 
 from . import util as util

--- a/src/splat/disassembler/spimdisasm_disassembler.py
+++ b/src/splat/disassembler/spimdisasm_disassembler.py
@@ -7,7 +7,7 @@ from typing import Set
 
 class SpimdisasmDisassembler(disassembler.Disassembler):
     # This value should be kept in sync with the version listed on requirements.txt and pyproject.toml
-    SPIMDISASM_MIN = (1, 31, 0)
+    SPIMDISASM_MIN = (1, 32, 0)
 
     def configure(self):
         # Configure spimdisasm

--- a/src/splat/segtypes/common/codesubsegment.py
+++ b/src/splat/segtypes/common/codesubsegment.py
@@ -122,7 +122,7 @@ class CommonSegCodeSubsegment(Segment):
         )
 
         # Gather symbols found by spimdisasm and create those symbols in splat's side
-        for referenced_vram in func_spim.instrAnalyzer.referencedVrams:
+        for referenced_vram in func_spim.referencedVrams:
             context_sym = self.spim_section.get_section().getSymbol(
                 referenced_vram, tryPlusOffset=False
             )

--- a/src/splat/segtypes/common/data.py
+++ b/src/splat/segtypes/common/data.py
@@ -145,6 +145,16 @@ class CommonSegData(CommonSegCodeSubsegment, CommonSegGroup):
                 self.get_most_parent(), symbol.contextSym
             )
 
+            # Gather symbols found by spimdisasm and create those symbols in splat's side
+            for referenced_vram in symbol.referencedVrams:
+                context_sym = self.spim_section.get_section().getSymbol(
+                    referenced_vram, tryPlusOffset=False
+                )
+                if context_sym is not None:
+                    symbols.create_symbol_from_spim_symbol(
+                        self.get_most_parent(), context_sym
+                    )
+
             # Hint to the user that we are now in the .rodata section and no longer in the .data section (assuming rodata follows data)
             if (
                 self.suggestion_rodata_section_start

--- a/src/splat/segtypes/common/rodata.py
+++ b/src/splat/segtypes/common/rodata.py
@@ -112,6 +112,16 @@ class CommonSegRodata(CommonSegData):
             )
             generated_symbol.linker_section = self.get_linker_section_linksection()
 
+            # Gather symbols found by spimdisasm and create those symbols in splat's side
+            for referenced_vram in symbol.referencedVrams:
+                context_sym = self.spim_section.get_section().getSymbol(
+                    referenced_vram, tryPlusOffset=False
+                )
+                if context_sym is not None:
+                    symbols.create_symbol_from_spim_symbol(
+                        self.get_most_parent(), context_sym
+                    )
+
             possible_text = self.get_possible_text_subsegment_for_symbol(symbol)
             if possible_text is not None:
                 text_segment, refenceeFunction = possible_text


### PR DESCRIPTION
This hopefully should fix some jumptable labels not using the proper naming format specified by the user

![image](https://github.com/user-attachments/assets/3ec7843b-b152-45c9-8d9e-a1ffb606cc2a)
