### PR TITLE
Slightly faster bss disassembly for huge segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # splat Release Notes
 
+### 0.32.3
+
+- Fix "unrecognized YAML option" error if disassemble_all is provided via CLI and as a YAML option.
+- Slightly speed up `bss` disassembly for projects over thousands of subsegments in the same top-level segment.
+
 ### 0.32.2
 
 * Fix jumptable labels not being properly formatted with the given `symbol_name_format`.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The brackets corresponds to the optional dependencies to install while installin
 If you use a `requirements.txt` file in your repository, then you can add this library with the following line:
 
 ```txt
-splat64[mips]>=0.32.2,<1.0.0
+splat64[mips]>=0.32.3,<1.0.0
 ```
 
 ### Optional dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.32.2"
+version = "0.32.3"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -1,7 +1,7 @@
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version__ = "0.32.2"
+__version__ = "0.32.3"
 __author__ = "ethteck"
 
 from . import util as util

--- a/src/splat/segtypes/common/bss.py
+++ b/src/splat/segtypes/common/bss.py
@@ -60,7 +60,9 @@ class CommonSegBss(CommonSegData):
                 f"Segment '{self.name}' (type '{self.type}') requires a vram address. Got '{self.vram_start}'"
             )
 
-        next_subsegment = self.parent.get_next_subsegment_for_ram(self.vram_start, self.index_within_group)
+        next_subsegment = self.parent.get_next_subsegment_for_ram(
+            self.vram_start, self.index_within_group
+        )
         if next_subsegment is None:
             bss_end = self.get_most_parent().vram_end
         else:

--- a/src/splat/segtypes/common/bss.py
+++ b/src/splat/segtypes/common/bss.py
@@ -60,7 +60,7 @@ class CommonSegBss(CommonSegData):
                 f"Segment '{self.name}' (type '{self.type}') requires a vram address. Got '{self.vram_start}'"
             )
 
-        next_subsegment = self.parent.get_next_subsegment_for_ram(self.vram_start)
+        next_subsegment = self.parent.get_next_subsegment_for_ram(self.vram_start, self.index_within_group)
         if next_subsegment is None:
             bss_end = self.get_most_parent().vram_end
         else:

--- a/src/splat/segtypes/common/code.py
+++ b/src/splat/segtypes/common/code.py
@@ -270,6 +270,8 @@ class CommonSegCode(CommonSegGroup):
                 sibling.siblings[segment.get_linker_section_linksection()] = segment
 
         ret = self._insert_all_auto_sections(ret, base_segments, readonly_before)
+        for i, seg in enumerate(ret):
+            seg.index_within_group = i
 
         return ret
 

--- a/src/splat/segtypes/common/group.py
+++ b/src/splat/segtypes/common/group.py
@@ -110,10 +110,15 @@ class CommonSegGroup(CommonSegment):
                 self.special_vram_segment = True
             segment.is_auto_segment = is_auto_segment
 
+            segment.index_within_group = len(ret)
+
             ret.append(segment)
             prev_start = start
             if end is not None:
                 last_rom_end = end
+
+        for i, seg in enumerate(ret):
+            seg.index_within_group = i
 
         return ret
 
@@ -165,13 +170,15 @@ class CommonSegGroup(CommonSegment):
                 return sub
         return None
 
-    def get_next_subsegment_for_ram(self, addr: int) -> Optional[Segment]:
+    def get_next_subsegment_for_ram(self, addr: int, current_subseg_index: Optional[int]) -> Optional[Segment]:
         """
         Returns the first subsegment which comes after the specified address,
         or None in case this address belongs to the last subsegment of this group
         """
 
-        for sub in self.subsegments:
+        start = current_subseg_index if current_subseg_index is not None else 0
+
+        for sub in self.subsegments[start:]:
             if sub.vram_start is None:
                 continue
             assert isinstance(sub.vram_start, int)

--- a/src/splat/segtypes/common/group.py
+++ b/src/splat/segtypes/common/group.py
@@ -170,7 +170,9 @@ class CommonSegGroup(CommonSegment):
                 return sub
         return None
 
-    def get_next_subsegment_for_ram(self, addr: int, current_subseg_index: Optional[int]) -> Optional[Segment]:
+    def get_next_subsegment_for_ram(
+        self, addr: int, current_subseg_index: Optional[int]
+    ) -> Optional[Segment]:
         """
         Returns the first subsegment which comes after the specified address,
         or None in case this address belongs to the last subsegment of this group

--- a/src/splat/segtypes/segment.py
+++ b/src/splat/segtypes/segment.py
@@ -354,6 +354,8 @@ class Segment:
         # Is an automatic segment, generated automatically or declared on the yaml by the user
         self.is_auto_segment: bool = False
 
+        self.index_within_group: Optional[int] = None
+
         if self.rom_start is not None and self.rom_end is not None:
             if self.rom_start > self.rom_end:
                 log.error(

--- a/src/splat/segtypes/segment.py
+++ b/src/splat/segtypes/segment.py
@@ -255,7 +255,7 @@ class Segment:
 
     @staticmethod
     def parse_suggestion_rodata_section_start(
-        yaml: Union[dict, list]
+        yaml: Union[dict, list],
     ) -> Optional[bool]:
         if isinstance(yaml, dict):
             suggestion_rodata_section_start = yaml.get(


### PR DESCRIPTION
Slightly speed up `bss` disassembly for projects over thousands of subsegments in the same top-level segment. Projects with saner amount of subsegments won't see a difference after this. I think this will be useful for PS2 projects

Measuring how much it takes to disassemble the hit and run project, which has over 3k subsegments:

- Before this PR
```
real    0m43.467s
user    0m42.275s
sys    0m0.925s
```

- After this PR
```
real    0m41.629s
user    0m40.556s
sys    0m0.983s
```