### PR TITLE
Separate Config from Split

### DIFF
--- a/src/splat/util/conf.py
+++ b/src/splat/util/conf.py
@@ -37,7 +37,9 @@ def _merge_configs(main_config, additional_config, additional_config_path):
             elif type(main_config[curkey]) == dict:
                 # need to merge sub areas
                 main_config[curkey] = _merge_configs(
-                    main_config[curkey], additional_config[curkey]
+                    main_config[curkey],
+                    additional_config[curkey],
+                    additional_config_path,
                 )
             else:
                 # not a list or dictionary, must be a number or string, overwrite

--- a/src/splat/util/conf.py
+++ b/src/splat/util/conf.py
@@ -1,0 +1,86 @@
+"""
+This module is used to load splat configuration from a YAML file.
+
+A config dict can be loaded using `load`.
+
+    config = conf.load("path/to/splat.yaml")
+"""
+
+from typing import Any, Dict, List, Optional
+from pathlib import Path
+
+# This unused import makes the yaml library faster. don't remove
+import pylibyaml  # pyright: ignore
+import yaml
+
+from . import log, options, vram_classes
+
+
+def _merge_configs(main_config, additional_config, additional_config_path):
+    # Merge rules are simple
+    # For each key in the dictionary
+    # - If list then append to list
+    # - If a dictionary then repeat merge on sub dictionary entries
+    # - Else assume string or number and replace entry
+
+    for curkey in additional_config:
+        if curkey not in main_config:
+            main_config[curkey] = additional_config[curkey]
+        elif type(main_config[curkey]) != type(additional_config[curkey]):
+            raise TypeError(
+                f"Could not merge {str(additional_config_path)}: type for key '{curkey}' in configs does not match"
+            )
+        else:
+            # keys exist and match, see if a list to append
+            if type(main_config[curkey]) == list:
+                main_config[curkey] += additional_config[curkey]
+            elif type(main_config[curkey]) == dict:
+                # need to merge sub areas
+                main_config[curkey] = _merge_configs(
+                    main_config[curkey], additional_config[curkey]
+                )
+            else:
+                # not a list or dictionary, must be a number or string, overwrite
+                main_config[curkey] = additional_config[curkey]
+
+    return main_config
+
+
+def load(
+    config_path: List[Path],
+    modes: Optional[List[str]] = None,
+    verbose: bool = False,
+    disassemble_all: bool = False,
+) -> Dict[str, Any]:
+    """
+    Returns a `dict` with resolved splat config.
+
+    Multiple configuration files can be passed in ``config_path`` with each subsequent file merged into the previous.
+
+    `modes` specifies which modes are active (all, code, img, gfx, vtx, etc.). The default is all.
+
+    `verbose` may be used to determine whether or not to display additional output.
+
+    `disassemble_all` determines whether functions which are already compiled will be disassembled. This is OR-ed with
+    the `disassemble_all` key in a config file, if present.
+
+    After all files are merged, static validation is done on the configuration.
+
+    The returned `dict` represents the merged and validated YAML config.
+
+    As a side effect, the global `splat.util.options.opts` is set.
+
+    Config with invalid options may raise an error.
+    """
+
+    config: Dict[str, Any] = {}
+    for entry in config_path:
+        with entry.open() as f:
+            additional_config = yaml.load(f.read(), Loader=yaml.SafeLoader)
+        config = _merge_configs(config, additional_config, entry)
+
+    vram_classes.initialize(config.get("vram_classes"))
+
+    options.initialize(config, config_path, modes, verbose, disassemble_all)
+
+    return config

--- a/src/splat/util/options.py
+++ b/src/splat/util/options.py
@@ -344,7 +344,7 @@ class OptParser:
 
 def _parse_yaml(
     yaml: Dict,
-    config_paths: List[str],
+    config_paths: List[Path],
     modes: List[str],
     verbose: bool = False,
     disasm_all: bool = False,
@@ -356,7 +356,7 @@ def _parse_yaml(
     comp = compiler.for_name(p.parse_opt("compiler", str, "IDO"))
 
     base_path = Path(
-        os.path.normpath(Path(config_paths[0]).parent / p.parse_opt("base_path", str))
+        os.path.normpath(config_paths[0].parent / p.parse_opt("base_path", str))
     )
     asm_path: Path = p.parse_path(base_path, "asm_path", "asm")
 
@@ -574,7 +574,7 @@ def _parse_yaml(
 
 def initialize(
     config: Dict,
-    config_paths: List[str],
+    config_paths: List[Path],
     modes: Optional[List[str]] = None,
     verbose=False,
     disasm_all=False,

--- a/test.py
+++ b/test.py
@@ -50,8 +50,10 @@ class Testing(unittest.TestCase):
             self.get_right_only_files(sub_dcmp, out)
 
     def test_basic_app(self):
+        import pathlib
+
         spimdisasm.common.GlobalConfig.ASM_GENERATED_BY = False
-        main(["test/basic_app/splat.yaml"], None, False)
+        main([pathlib.Path("test/basic_app/splat.yaml")], None, False)
 
         comparison = filecmp.dircmp(
             "test/basic_app/split", "test/basic_app/expected", [".gitkeep"]
@@ -95,6 +97,8 @@ class Testing(unittest.TestCase):
 
 
 def test_init():
+    import pathlib
+
     options_dict = {
         "options": {
             "platform": "n64",
@@ -123,7 +127,9 @@ def test_init():
             [0x1290],
         ],
     }
-    options.initialize(options_dict, ["./test/basic_app/splat.yaml"], [], False)
+    options.initialize(
+        options_dict, [pathlib.Path("./test/basic_app/splat.yaml")], [], False
+    )
 
 
 class Symbols(unittest.TestCase):

--- a/test.py
+++ b/test.py
@@ -6,6 +6,7 @@ from src.splat.scripts.split import *
 import unittest
 import io
 import filecmp
+import pathlib
 from src.splat.util import symbols, options
 import spimdisasm
 from src.splat.segtypes.common.rodata import CommonSegRodata
@@ -50,8 +51,6 @@ class Testing(unittest.TestCase):
             self.get_right_only_files(sub_dcmp, out)
 
     def test_basic_app(self):
-        import pathlib
-
         spimdisasm.common.GlobalConfig.ASM_GENERATED_BY = False
         main([pathlib.Path("test/basic_app/splat.yaml")], None, False)
 
@@ -97,8 +96,6 @@ class Testing(unittest.TestCase):
 
 
 def test_init():
-    import pathlib
-
     options_dict = {
         "options": {
             "platform": "n64",
@@ -348,8 +345,6 @@ class Bss(unittest.TestCase):
 
 class SymbolsInitialize(unittest.TestCase):
     def test_attrs(self):
-        import pathlib
-
         symbols.reset_symbols()
         test_init()
 
@@ -380,8 +375,6 @@ class SymbolsInitialize(unittest.TestCase):
         assert symbols.all_symbols[0].given_name_end == "the_name_end"
 
     def test_boolean_attrs(self):
-        import pathlib
-
         symbols.reset_symbols()
         test_init()
 
@@ -413,8 +406,6 @@ class SymbolsInitialize(unittest.TestCase):
 
     # test spim ban range
     def test_ignore(self):
-        import pathlib
-
         symbols.reset_symbols()
         test_init()
 


### PR DESCRIPTION
Moves splat config loading and parsing into `splat.util.conf` to make it available to other projects.

`initialize_config` is now `splat.util.conf.load`. It takes `Path`s instead of `str`s for YAML paths. It will no longer `exit` if config merging fails, but will throw a `TypeError` which can be handled as desired by callers.