### PR TITLE
Fix include macros when generated on windows

### DIFF
--- a/src/splat/segtypes/common/c.py
+++ b/src/splat/segtypes/common/c.py
@@ -380,7 +380,7 @@ class CommonSegC(CommonSegCodeSubsegment):
             # IDO uses the asm processor to embeed assembly, and it doesn't require a special directive to include symbols
             asm_outpath = asm_out_dir / self.name / f"{sym.filename}.s"
             rel_asm_outpath = os.path.relpath(asm_outpath, options.opts.base_path)
-            final_path = Path(f"{rel_asm_outpath}").as_posix()
+            final_path = Path(rel_asm_outpath).as_posix()
             return f'#pragma GLOBAL_ASM("{final_path}")'
 
         if options.opts.use_legacy_include_asm:

--- a/src/splat/segtypes/common/c.py
+++ b/src/splat/segtypes/common/c.py
@@ -385,10 +385,10 @@ class CommonSegC(CommonSegCodeSubsegment):
 
         if options.opts.use_legacy_include_asm:
             rel_asm_out_dir = asm_out_dir.relative_to(options.opts.nonmatchings_path)
-            final_path = f"{(rel_asm_out_dir / self.name).as_posix()}"
+            final_path = (rel_asm_out_dir / self.name).as_posix()
             return f'{macro_name}(const s32, "{final_path}", {sym.filename});'
 
-        final_path = f"{(asm_out_dir / self.name).as_posix()}"
+        final_path = (asm_out_dir / self.name).as_posix()
         return f'{macro_name}("{final_path}", {sym.filename});'
 
     def get_c_lines_for_function(

--- a/src/splat/segtypes/common/c.py
+++ b/src/splat/segtypes/common/c.py
@@ -1,7 +1,6 @@
 import os
 import re
 from pathlib import Path
-from pathlib import PureWindowsPath
 from typing import Optional, Set, List
 
 import rabbitizer
@@ -381,15 +380,15 @@ class CommonSegC(CommonSegCodeSubsegment):
             # IDO uses the asm processor to embeed assembly, and it doesn't require a special directive to include symbols
             asm_outpath = asm_out_dir / self.name / f"{sym.filename}.s"
             rel_asm_outpath = os.path.relpath(asm_outpath, options.opts.base_path)
-            final_path = PureWindowsPath(f"{rel_asm_outpath}").as_posix()
+            final_path = Path(f"{rel_asm_outpath}").as_posix()
             return f'#pragma GLOBAL_ASM("{final_path}")'
 
         if options.opts.use_legacy_include_asm:
             rel_asm_out_dir = asm_out_dir.relative_to(options.opts.nonmatchings_path)
-            final_path = f'{(rel_asm_out_dir / self.name).as_posix()}'
+            final_path = f"{(rel_asm_out_dir / self.name).as_posix()}"
             return f'{macro_name}(const s32, "{final_path}", {sym.filename});'
 
-        final_path = f'{(asm_out_dir / self.name).as_posix()}'
+        final_path = f"{(asm_out_dir / self.name).as_posix()}"
         return f'{macro_name}("{final_path}", {sym.filename});'
 
     def get_c_lines_for_function(

--- a/src/splat/segtypes/common/c.py
+++ b/src/splat/segtypes/common/c.py
@@ -1,6 +1,7 @@
 import os
 import re
 from pathlib import Path
+from pathlib import PureWindowsPath
 from typing import Optional, Set, List
 
 import rabbitizer
@@ -380,13 +381,16 @@ class CommonSegC(CommonSegCodeSubsegment):
             # IDO uses the asm processor to embeed assembly, and it doesn't require a special directive to include symbols
             asm_outpath = asm_out_dir / self.name / f"{sym.filename}.s"
             rel_asm_outpath = os.path.relpath(asm_outpath, options.opts.base_path)
-            return f'#pragma GLOBAL_ASM("{rel_asm_outpath}")'
+            final_path = PureWindowsPath(f"{rel_asm_outpath}").as_posix()
+            return f'#pragma GLOBAL_ASM("{final_path}")'
 
         if options.opts.use_legacy_include_asm:
             rel_asm_out_dir = asm_out_dir.relative_to(options.opts.nonmatchings_path)
-            return f'{macro_name}(const s32, "{rel_asm_out_dir / self.name}", {sym.filename});'
+            final_path = f'{(rel_asm_out_dir / self.name).as_posix()}'
+            return f'{macro_name}(const s32, "{final_path}", {sym.filename});'
 
-        return f'{macro_name}("{asm_out_dir / self.name}", {sym.filename});'
+        final_path = f'{(asm_out_dir / self.name).as_posix()}'
+        return f'{macro_name}("{final_path}", {sym.filename});'
 
     def get_c_lines_for_function(
         self,

--- a/src/splat/segtypes/common/textbin.py
+++ b/src/splat/segtypes/common/textbin.py
@@ -85,7 +85,7 @@ class CommonSegTextbin(CommonSegment):
             f.write(f"{asm_label} {sym.name}\n")
             sym.defined = True
 
-        f.write(f'.incbin "{binpath}"\n')
+        f.write(f'.incbin "{binpath.as_posix()}"\n')
 
         if sym is not None:
             if self.is_text() and options.opts.asm_end_label != "":


### PR DESCRIPTION
The generation of these macros uses a path class which outputs slashes relative to the OS. This creates an issue when splat is run on windows, as it will generate:
`INCLUDE_ASM("asm\nonmatchings\game", func_800AF980);`
The preprocessor will then treat these as escape sequences and do wild things. This fix forces it to always use unix paths regardless of OS:
`INCLUDE_ASM("asm/nonmatchings/game", func_800AF980);`