### PR TITLE
Fix output of incbins for SN64

### DIFF
--- a/src/splat/segtypes/common/textbin.py
+++ b/src/splat/segtypes/common/textbin.py
@@ -83,6 +83,11 @@ class CommonSegTextbin(CommonSegment):
 
         if sym is not None:
             f.write(f"{asm_label} {sym.name}\n")
+            if self.is_text() and asm_label == ".globl":
+                f.write(f".ent {sym.name}\n")
+                f.write(f"{sym.name}:\n")
+            if not self.is_text() and asm_label == ".globl":
+                f.write(f"{sym.name}:\n")
             sym.defined = True
 
         f.write(f'.incbin "{binpath.as_posix()}"\n')

--- a/src/splat/segtypes/common/textbin.py
+++ b/src/splat/segtypes/common/textbin.py
@@ -101,6 +101,8 @@ class CommonSegTextbin(CommonSegment):
                     or sym.given_size == self.rom_end - self.rom_start
                 ):
                     f.write(f"{asm_label} {sym.given_name_end}\n")
+                    if asm_label == ".globl":
+                        f.write(f"{sym.given_name_end}:\n")
 
     def split(self, rom_bytes):
         if self.rom_end is None:

--- a/src/splat/segtypes/common/textbin.py
+++ b/src/splat/segtypes/common/textbin.py
@@ -83,10 +83,9 @@ class CommonSegTextbin(CommonSegment):
 
         if sym is not None:
             f.write(f"{asm_label} {sym.name}\n")
-            if self.is_text() and asm_label == ".globl":
-                f.write(f".ent {sym.name}\n")
-                f.write(f"{sym.name}:\n")
-            if not self.is_text() and asm_label == ".globl":
+            if asm_label == ".globl":
+                if self.is_text():
+                    f.write(f".ent {sym.name}\n")
                 f.write(f"{sym.name}:\n")
             sym.defined = True
 

--- a/src/splat/util/compiler.py
+++ b/src/splat/util/compiler.py
@@ -26,6 +26,7 @@ GCC = Compiler(
 SN64 = Compiler(
     "SN64",
     asm_function_macro=".globl",
+    asm_function_alt_macro=".globl",
     asm_jtbl_label_macro=".globl",
     asm_data_macro=".globl",
     asm_end_label=".end",


### PR DESCRIPTION
ASN64 requires labels to be used for globals in order to access them, which by default, are not generated for text/(ro)databins. It is however generated for regular code, as [shown here](https://github.com/ethteck/splat/blob/main/src/splat/disassembler/spimdisasm_disassembler.py#L105). I simply mimicked the same logic for the incbin generation. With this fix, an SN64 rom can now be split and reassembled to bin exactness without any manual changes done to splat's output, via `modern-asn64`.

Before:
```
.globl gspF3DEX2_fifoTextStart
.incbin "assets/rsp/gspF3DEX2_fifo.textbin.bin"
.end gspF3DEX2_fifoTextStart
```
After:
```
.globl gspF3DEX2_fifoTextStart
.ent gspF3DEX2_fifoTextStart
gspF3DEX2_fifoTextStart:
.incbin "assets/rsp/gspF3DEX2_fifo.textbin.bin"
.end gspF3DEX2_fifoTextStart
```