### PR TITLE
Wiki: Add mention for workflow on include_asm with mwcc

### DIFF
--- a/docs/General-Workflow.md
+++ b/docs/General-Workflow.md
@@ -124,6 +124,8 @@ For a GCC example, see the [include.h](https://github.com/AngheloAlf/drmario64/b
 
 For IDO, you will need to use [asm-processor](https://github.com/simonlindholm/asm-processor) in order to include assembly code within the c files.
 
+For MWCC, you will need [mwccgap](https://github.com/mkst/mwccgap) to include assembly code in the c files, similar to asm-processor.
+
 ## Assembly macros
 
 splat relies on some assembly macros for the asm generation. They usually live on the `include/macro.inc` file. Without these macros then an assembler would not be able to build our disassemblies.


### PR DESCRIPTION
## Description:
The wiki currently mentions how to handle INCLUDE_ASM for IDO using asm-processor. This adds a brief mention for what to use for MWCC compilers as well for the same purpose with mwccgap.