### PR TITLE
Emit an error if `bss_size` is missing on segments that do contain `bss` sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,26 @@
 # splat Release Notes
 
+### 0.34.2
+
+* Emit an error if a top-level segment containing bss sections does not specify a `bss_size` value.
+* Emit an error if a bss section is outside the address space of its parent segment.
+
 ### 0.34.1
+
 * Deprecate `--stdout-only` cli flag. Changed output such that errors and warnings go to stderr and all other output goes to stdout.
 
 ### 0.34.0
+
 * Add new global option `is_unsupported_platform`. If enabled, disable checks on platform option.
 * Add new global option `allow_segment_overrides`. If enabled, allows to take precedence over the splat builtin platform segments via splat extension.
 
 ### 0.33.2
+
 * Change `make_full_disasm_for_code` to output other sections for the TU in addition to .text.
 
 ### 0.33.1
-* Fix `hasm` segments overwriting files already on disk
+
+* Fix `hasm` segments overwriting files already on disk.
 
 ### 0.33.0
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The brackets corresponds to the optional dependencies to install while installin
 If you use a `requirements.txt` file in your repository, then you can add this library with the following line:
 
 ```txt
-splat64[mips]>=0.34.1,<1.0.0
+splat64[mips]>=0.34.2,<1.0.0
 ```
 
 ### Optional dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.34.1"
+version = "0.34.2"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -1,7 +1,7 @@
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version__ = "0.34.1"
+__version__ = "0.34.2"
 __author__ = "ethteck"
 
 from . import util as util

--- a/src/splat/segtypes/segment.py
+++ b/src/splat/segtypes/segment.py
@@ -417,13 +417,22 @@ class Segment:
         # Import here to avoid circular imports
         from .common.code import CommonSegCode
         from .common.bss import CommonSegBss
+
         if options.opts.ld_bss_is_noload and isinstance(ret, CommonSegBss):
             # We need to know the bss space for the segment.
             if isinstance(parent, CommonSegCode):
                 if parent.bss_size <= 0:
-                    log.error(f"Top-level segment '{parent.name}' is missing a `bss_size` value.\n    A non-zero `bss_size` value must be defined on the top-level segments that contain '{ret.type}' sections (produced by the '{ret.name}' section).")
-                if isinstance(ret.vram_start, int) and isinstance(parent.vram_end, int) and ret.vram_start >= parent.vram_end:
-                    log.error(f"The section '{ret.name}' (vram 0x{ret.vram_start:08X}) is outside its parent's address range '{parent.name}' (0x{parent.vram_start:08X} ~ 0x{parent.vram_end:08X}).\n    This may happen when the specified `bss_size` value is too small.")
+                    log.error(
+                        f"Top-level segment '{parent.name}' is missing a `bss_size` value.\n    A non-zero `bss_size` value must be defined on the top-level segments that contain '{ret.type}' sections (produced by the '{ret.name}' section)."
+                    )
+                if (
+                    isinstance(ret.vram_start, int)
+                    and isinstance(parent.vram_end, int)
+                    and ret.vram_start >= parent.vram_end
+                ):
+                    log.error(
+                        f"The section '{ret.name}' (vram 0x{ret.vram_start:08X}) is outside its parent's address range '{parent.name}' (0x{parent.vram_start:08X} ~ 0x{parent.vram_end:08X}).\n    This may happen when the specified `bss_size` value is too small."
+                    )
 
         ret.given_section_order = parse_segment_section_order(yaml)
         ret.given_subalign = parse_segment_subalign(yaml)

--- a/src/splat/segtypes/segment.py
+++ b/src/splat/segtypes/segment.py
@@ -414,6 +414,17 @@ class Segment:
 
         ret.parent = parent
 
+        # Import here to avoid circular imports
+        from .common.code import CommonSegCode
+        from .common.bss import CommonSegBss
+        if options.opts.ld_bss_is_noload and isinstance(ret, CommonSegBss):
+            # We need to know the bss space for the segment.
+            if isinstance(parent, CommonSegCode):
+                if parent.bss_size <= 0:
+                    log.error(f"Top-level segment '{parent.name}' is missing a `bss_size` value.\n    A non-zero `bss_size` value must be defined on the top-level segments that contain '{ret.type}' sections (produced by the '{ret.name}' section).")
+                if isinstance(ret.vram_start, int) and isinstance(parent.vram_end, int) and ret.vram_start >= parent.vram_end:
+                    log.error(f"The section '{ret.name}' (vram 0x{ret.vram_start:08X}) is outside its parent's address range '{parent.name}' (0x{parent.vram_start:08X} ~ 0x{parent.vram_end:08X}).\n    This may happen when the specified `bss_size` value is too small.")
+
         ret.given_section_order = parse_segment_section_order(yaml)
         ret.given_subalign = parse_segment_subalign(yaml)
 

--- a/test.py
+++ b/test.py
@@ -456,11 +456,11 @@ class InitializeSpimContext(unittest.TestCase):
 
         all_segments: List["Segment"] = [
             CommonSegCode(
-                rom_start=0x0,
-                rom_end=0x200,
+                rom_start=0x1000,
+                rom_end=0x1140,
                 type="code",
                 name="main",
-                vram_start=0x100,
+                vram_start=0x80000400,
                 args=[],
                 yaml=yaml,
             )
@@ -472,7 +472,7 @@ class InitializeSpimContext(unittest.TestCase):
         symbols.initialize_spim_context(all_segments)
         # spim should have added something to overlaySegments
         assert (
-            type(symbols.spim_context.overlaySegments["overlay"][0])
+            type(symbols.spim_context.overlaySegments["overlay"][0x1000])
             == spimdisasm.common.SymbolsSegment
         )
 
@@ -485,22 +485,21 @@ class InitializeSpimContext(unittest.TestCase):
             "name": "boot",
             "type": "code",
             "start": 0x1000,
-            "vram": 0x80000400,
+            "vram": 0x100,
             "bss_size": 0x80,
-            "exclusive_ram_id": "overlay",
             "subsegments": [
                 [0x1000, "c", "main"],
                 [0x10F0, "hasm", "handwritten"],
                 [0x1100, "data", "main"],
                 [0x1110, ".rodata", "main"],
-                {"start": 0x1140, "type": "bss", "vram": 0x80000540, "name": "main"},
+                {"start": 0x1140, "type": "bss", "vram": 0x240, "name": "main"},
             ],
         }
 
         all_segments: List["Segment"] = [
             CommonSegCode(
-                rom_start=0x0,
-                rom_end=0x200,
+                rom_start=0x1000,
+                rom_end=0x1140,
                 type="code",
                 name="main",
                 vram_start=0x100,
@@ -513,7 +512,7 @@ class InitializeSpimContext(unittest.TestCase):
         assert symbols.spim_context.globalSegment.vramEnd == 0x80001000
         symbols.initialize_spim_context(all_segments)
         assert symbols.spim_context.globalSegment.vramStart == 0x100
-        assert symbols.spim_context.globalSegment.vramEnd == 0x380
+        assert symbols.spim_context.globalSegment.vramEnd == 0x2C0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Also checks if a bss section is somehow outside it's parent segment's address space, which may be caused by a `bss_size` value being too small.

These checks aren't performed if `ld_bss_is_noload` is disabled, like for psx projects.
