### PR TITLE
Add the size directive to textbin files

### DIFF
--- a/src/splat/segtypes/common/textbin.py
+++ b/src/splat/segtypes/common/textbin.py
@@ -95,7 +95,6 @@ class CommonSegTextbin(CommonSegment):
             if options.opts.asm_emit_size_directive:
                 f.write(f".size {sym.name}, . - {sym.name}\n")
 
-        if sym is not None:
             if self.is_text() and options.opts.asm_end_label != "":
                 f.write(f"{options.opts.asm_end_label} {sym.name}\n")
 


### PR DESCRIPTION
This utilizes the existing splat option `asm_emit_size_directive` to decide whether or not to add a .size command to the textbin file, mostly used for ucodes.

Before example:
```asm
.include "macro.inc"

.section .text, "ax"

glabel aspMainTextStart
.incbin "assets/aspMain.textbin.bin"
glabel aspMainTextEnd

.section .data, "wa"

dlabel aspMainDataStart
.incbin "assets/aspMain.databin.bin"
dlabel aspMainDataEnd
```

After example:
```asm
.include "macro.inc"

.section .text, "ax"

glabel aspMainTextStart
.incbin "assets/aspMain.textbin.bin"
.size aspMainTextStart, . - aspMainTextStart
glabel aspMainTextEnd

.section .data, "wa"

dlabel aspMainDataStart
.incbin "assets/aspMain.databin.bin"
.size aspMainDataStart, . - aspMainDataStart
dlabel aspMainDataEnd
```