### PR TITLE
Fix missing dot at `.include` in generated `macro.inc` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # splat Release Notes
 
+### 0.35.1
+
+* Fixes a typo in the generated `macro.inc` file on psx projects.
+
 ### 0.35.0
 
 * Add `pair_segment` option to segments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### 0.35.1
 
-* Fixes a typo in the generated `macro.inc` file on psx projects.
+* Fixes issues in the generated `macro.inc` and `labels.inc` files on psx projects.
+* Change `jlabel`s to be global if the user has turned off rodata migration to functions.
 
 ### 0.35.0
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The brackets corresponds to the optional dependencies to install while installin
 If you use a `requirements.txt` file in your repository, then you can add this library with the following line:
 
 ```txt
-splat64[mips]>=0.35.0,<1.0.0
+splat64[mips]>=0.35.1,<1.0.0
 ```
 
 ### Optional dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.35.0"
+version = "0.35.1"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -1,7 +1,7 @@
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version__ = "0.35.0"
+__version__ = "0.35.1"
 __author__ = "ethteck"
 
 from . import util as util

--- a/src/splat/util/file_presets.py
+++ b/src/splat/util/file_presets.py
@@ -122,12 +122,6 @@ def write_assembly_inc_files():
         options.opts.asm_jtbl_label_macro != ""
         and options.opts.asm_jtbl_label_macro != options.opts.asm_function_macro
     ):
-        jlabel_macro_labelsinc = f"""
-# A label referenced by a jumptable.
-.macro {options.opts.asm_jtbl_label_macro} label, visibility=global
-    \\label:
-.endm
-"""
         jlabel_macro_macroinc = f"""
 # A label referenced by a jumptable.
 .macro {options.opts.asm_jtbl_label_macro} label, visibility=global
@@ -136,6 +130,18 @@ def write_assembly_inc_files():
     \\label:
 .endm
 """
+        if options.opts.migrate_rodata_to_functions:
+            jlabel_macro_labelsinc = f"""
+# A label referenced by a jumptable.
+.macro {options.opts.asm_jtbl_label_macro} label, visibility=global
+    \\label:
+.endm
+"""
+        else:
+            # If the user doesn't migrate rodata, like jumptables, to functions
+            # then the user will need jlabels to be global instead of local,
+            # so we just reuse the definition from macro.inc
+            jlabel_macro_labelsinc = jlabel_macro_macroinc
 
     data_macros = ""
     if (

--- a/src/splat/util/file_presets.py
+++ b/src/splat/util/file_presets.py
@@ -186,6 +186,9 @@ def write_assembly_inc_files():
     if options.opts.compiler.uses_include_asm:
         # File used by original assembler
         preamble = "# This file is used by the original compiler/assembler.\n# Defines the expected assembly macros.\n"
+
+        if options.opts.platform == "psx":
+            preamble += '\n.include "gte_macros.inc"\n'
         _write("include/labels.inc", f"{preamble}\n{labels_inc}")
 
     if options.opts.platform in {"n64", "psx"}:

--- a/src/splat/util/file_presets.py
+++ b/src/splat/util/file_presets.py
@@ -275,7 +275,7 @@ def write_assembly_inc_files():
 .set $fs5f,         $f31
 """
     elif options.opts.platform == "psx":
-        gas += '\ninclude "gte_macros.inc"\n'
+        gas += '\n.include "gte_macros.inc"\n'
         write_gte_macros()
 
     if options.opts.generated_macro_inc_content is not None:


### PR DESCRIPTION
We missed a dot in the include directive in the generated `macro.inc` file.

This only affects psx projects.

Fixes #470 
