### PR TITLE
Fix `generate_asm_macros_files` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # splat Release Notes
 
+### 0.35.2
+
+* Fix splat not respecting when `generate_asm_macros_files` was being turned off.
+
 ### 0.35.1
 
 * Fixes issues in the generated `macro.inc` and `labels.inc` files on psx projects.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The brackets corresponds to the optional dependencies to install while installin
 If you use a `requirements.txt` file in your repository, then you can add this library with the following line:
 
 ```txt
-splat64[mips]>=0.35.1,<1.0.0
+splat64[mips]>=0.35.2,<1.0.0
 ```
 
 ### Optional dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.35.1"
+version = "0.35.2"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 
 [project.optional-dependencies]
 mips = [
-    "spimdisasm>=1.32.0,<2.0.0", # This value should be keep in sync with the version listed on disassembler/spimdisasm_disassembler.py
+    "spimdisasm>=1.36.0,<2.0.0", # This value should be keep in sync with the version listed on disassembler/spimdisasm_disassembler.py
     "rabbitizer>=1.12.0,<2.0.0",
     "pygfxd",
     "n64img>=0.3.3",

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -1,7 +1,7 @@
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version__ = "0.35.1"
+__version__ = "0.35.2"
 __author__ = "ethteck"
 
 from . import util as util

--- a/src/splat/util/file_presets.py
+++ b/src/splat/util/file_presets.py
@@ -14,6 +14,9 @@ from . import options, log
 
 
 def write_all_files():
+    if not options.opts.generate_asm_macros_files:
+        return
+
     write_include_asm_h()
     write_assembly_inc_files()
 


### PR DESCRIPTION
splat was ignoring when you turn off the `generate_asm_macros_files` option. My bad.

Fixes #472 
