### PR TITLE
Fix forcing eol LF on N64

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Force LF on everyfile
-* text eol=lf
+* text=auto eol=lf


### PR DESCRIPTION
Using the project as a submodule on Mac changes the eol to CRLF for segtypes/N64/i1.py. I'm not sure why it's this one specific file

