### PR TITLE
GTE macros update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # splat Release Notes
 
+### 0.36.2
+
+* Update GTE macros to use the new `dpct` encoding used by `rabbitizer` 1.14.0.
+  * The new encoding exposes some garbage bits used by this instruction that are not always the same on every psx project.
+* `rabbitizer` 1.14.0 or above is now required.
+
 ### 0.36.1
+
 * Files generated with `generate_asm_macros_files` will not be overwritten if they already exist on disk unchanged.
-* Updated GTE macros to better document opcode encodings
+* Updated GTE macros to better document opcode encodings.
 
 ### 0.36.0
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The brackets corresponds to the optional dependencies to install while installin
 If you use a `requirements.txt` file in your repository, then you can add this library with the following line:
 
 ```txt
-splat64[mips]>=0.36.1,<1.0.0
+splat64[mips]>=0.36.2,<1.0.0
 ```
 
 ### Optional dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.36.1"
+version = "0.36.2"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -21,7 +21,7 @@ dependencies = [
 [project.optional-dependencies]
 mips = [
     "spimdisasm>=1.36.1,<2.0.0", # This value should be keep in sync with the version listed on disassembler/spimdisasm_disassembler.py
-    "rabbitizer>=1.12.0,<2.0.0",
+    "rabbitizer>=1.14.0,<2.0.0",
     "pygfxd",
     "n64img>=0.3.3",
     "crunch64>=0.5.1,<1.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ intervaltree
 colorama
 # This value should be keep in sync with the version listed on disassembler/spimdisasm_disassembler.py and pyproject.toml
 spimdisasm>=1.36.1
-rabbitizer>=1.10.0
+rabbitizer>=1.14.0
 pygfxd
 n64img>=0.1.4
 crunch64>=0.2.0

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -1,7 +1,7 @@
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version__ = "0.36.1"
+__version__ = "0.36.2"
 __author__ = "ethteck"
 
 from . import util as util

--- a/src/splat/segtypes/linker_entry.py
+++ b/src/splat/segtypes/linker_entry.py
@@ -594,7 +594,7 @@ class LinkerWriter:
         if not noload:
             seg_rom_start = get_segment_rom_start(seg_name)
             line += f" AT({seg_rom_start})"
-        if options.opts.emit_subalign and segment.subalign != None:
+        if options.opts.emit_subalign and segment.subalign is not None:
             line += f" SUBALIGN({segment.subalign})"
 
         self._writeln(line)
@@ -636,7 +636,7 @@ class LinkerWriter:
         if noload:
             line += " (NOLOAD)"
         line += " :"
-        if options.opts.emit_subalign and segment.subalign != None:
+        if options.opts.emit_subalign and segment.subalign is not None:
             line += f" SUBALIGN({segment.subalign})"
 
         self._writeln(line)

--- a/src/splat/segtypes/segment.py
+++ b/src/splat/segtypes/segment.py
@@ -56,7 +56,7 @@ def parse_segment_subalign(segment: Union[dict, list]) -> Optional[int]:
     default = options.opts.subalign
     if isinstance(segment, dict):
         subalign = segment.get("subalign", default)
-        if subalign != None:
+        if subalign is not None:
             subalign = int(subalign)
         return subalign
     return default

--- a/src/splat/util/file_presets.py
+++ b/src/splat/util/file_presets.py
@@ -344,15 +344,15 @@ def write_assembly_inc_files():
 def write_gte_macros():
     # Taken directly from https://github.com/Decompollaborate/rabbitizer/blob/develop/docs/r3000gte/gte_macros.s
     # Please try to upstream any fix/update done here.
-    gte_macros = """
+    gte_macros = """\
 .ifndef .L_GTE_MACRO_INC
 .L_GTE_MACRO_INC:
 
 ## GTE instruction macros
 ## These are meant for use with GAS and replace DMPSX
 
-.macro cop2op pseudo, op, sf = 1, mx = 0, v = 0, cv = 0, lm = 0
-    cop2 \\pseudo << 20 | \\sf << 19 | \\mx << 17 | \\v << 15 | \\cv << 13 | \\lm << 10 | \\op
+.macro cop2op pseudo, op, gbg = 0, sf = 1, mx = 0, v = 0, cv = 0, lm = 0
+    cop2 \\pseudo << 20 | \\gbg << 20 | \\sf << 19 | \\mx << 17 | \\v << 15 | \\cv << 13 | \\lm << 10 | \\op
 .endm
 
 /*  RTPS    15      0x4A180001  Perspective transform */
@@ -373,11 +373,6 @@ def write_gte_macros():
 /*  DPCS    8       0x4A780010  Depth Cueing */
 .macro dpcs
     cop2op 0x07, 0x10
-.endm
-
-/*  DPCT    17      0x4A88002A  Depth cue color RGB0,RGB1,RGB2 */
-.macro dpct
-    cop2op 0x08, 0x2A
 .endm
 
 /*  INTPL   8       0x4A980011  Interpolation of vector and far color */
@@ -442,11 +437,17 @@ def write_gte_macros():
 
 
 ## Instructions which take an argument
+# gbg: arg is 5 bit wide
 # sf : arg is 1 bit wide
 # mx : arg is 2 bit wide
 # v  : arg is 2 bit wide
 # cv : arg is 2 bit wide
 # lm : arg is 1 bit wide
+
+/*  DPCT    17      0x4A88002A  Depth cue color RGB0,RGB1,RGB2 */
+.macro dpct gbg
+    cop2op 0x0F, 0x2A, gbg = \\gbg
+.endm
 
 /*  mvmva   8       0x4A4nnn12  Multiply vector by matrix and vector addition. */
 .macro mvmva sf, mx, v, cv, lm


### PR DESCRIPTION
The changes to the `dpct` macro in `gte_macros.s` introduced by #481 seem to produce non matching builds on some other PSX games, meaning the exact garbage bits of this instruction are required.

Because of this, `rabbitizer` now added a new argument to this instruction exposing any of the garbage bits encoded on the actual binary on [version 1.14.0](https://github.com/Decompollaborate/rabbitizer/releases/tag/1.14.0) onwards https://github.com/Decompollaborate/rabbitizer/pull/81 .

This PR updates the definition of the `dpct` macro on the autogenerated `gte_macros.s` file