### PR TITLE
Add mypy back again

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,3 +53,52 @@ jobs:
 
       - name: ruff test
         run: ruff check test.py
+
+  mypy_splat_checks:
+    runs-on: ubuntu-latest
+    name: mypy splat lib
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@main
+
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.9
+
+    - name: Install Dependencies
+      run: |
+        pip install mypy
+        pip install -r requirements.txt
+        pip install types-PyYAML
+        pip install -e .
+
+    - name: mypy splat lib
+      run: mypy --show-column-numbers --hide-error-context src/splat
+
+  mypy_programs_checks:
+    runs-on: ubuntu-latest
+    name: mypy splat programs
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@main
+
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.9
+
+    - name: Install Dependencies
+      run: |
+        pip install mypy
+        pip install -r requirements.txt
+        pip install types-PyYAML
+
+    - name: mypy split
+      run: mypy --show-column-numbers --hide-error-context split.py
+
+    - name: mypy create_config
+      run: mypy --show-column-numbers --hide-error-context create_config.py
+
+    - name: mypy test
+      run: mypy --show-column-numbers --hide-error-context test.py

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+ignore_missing_imports = True
+check_untyped_defs = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ mips = [
 dev = [
     "splat64[mips]",
     "ruff",
+    "mypy",
     "types-PyYAML",
     "types-colorama",
 ]


### PR DESCRIPTION
I was under the impression that `ruff check` could replace what `mypy` does, but I was wrong.

The mypy replacement is https://github.com/astral-sh/ty, but sadly that tool is still a work in progress.
I tried it out, but it triggers a few fake checks that don't need a fix. Hopefully we can use it in the near future.

