### PR TITLE
Add PS2 support in `create_config`

### DIFF
--- a/create_config.py
+++ b/create_config.py
@@ -1,9 +1,7 @@
 #! /usr/bin/env python3
 
-from pathlib import Path
-
 import src.splat as splat
 
 if __name__ == "__main__":
     args = splat.scripts.create_config.parser.parse_args()
-    splat.scripts.create_config.main(Path(args.file))
+    splat.scripts.create_config.process_arguments(args)

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -22,4 +22,4 @@ After scanning and splitting, **splat** will output a linker script that can be 
 
 ### Sounds great, how do I get started?
 
-Have a look at the [Quickstart](https://github.com/ethteck/splat/wiki/Quickstart), or check out the [Examples](https://github.com/ethteck/splat/wiki/Examples) page to see projects that are using **splat**.
+Have a look at the [Quickstart](https://github.com/ethteck/splat/wiki/Quickstart), [Quickstart for PS2 ELFs](https://github.com/ethteck/splat/wiki/Quickstart-Elf), or check out the [Examples](https://github.com/ethteck/splat/wiki/Examples) page to see projects that are using **splat**.

--- a/docs/Quickstart-Elf.md
+++ b/docs/Quickstart-Elf.md
@@ -1,0 +1,199 @@
+# Quickstart Elf
+
+> [!NOTE]
+> This quickstart is written with PS2 ELFs in mind, relocatable ELFs are not supported. It is also assumed that you are using Ubuntu 22.04 either natively, via WSL2 or via Docker.
+
+For the purposes of this quickstart, we will assume that we are going to split a game called `mygame` and we have the ELF from the iso named `SLUS_XXX.YY`.
+
+Create a directory for `~/mygame` and `cd` into it:
+
+```sh
+mkdir -p ${HOME}/mygame && cd ${HOME}/mygame
+```
+
+Copy the `SLUS_XXX.YY` file into the `mygame` directory inside your home directory.
+
+## System packages
+
+### Python 3.9
+
+Ensure you are have **Python 3.9** or higher installed:
+
+```sh
+$ python3 --version
+Python 3.9.10
+```
+
+If you get `bash: python3: command not found` install it with the following command:
+
+```sh
+sudo apt update && sudo apt install -y python3 python3-pip
+```
+
+### MIPS binutils
+
+Ensure you have a MIPS binutils installed in your PC. Specifically we'll need a MIPS `objcopy`.
+
+```sh
+$ mips-linux-gnu-objcopy --version
+GNU objcopy (GNU Binutils for Ubuntu) 2.38
+```
+
+If you get an error then install it with the following command:
+
+```sh
+sudo apt install binutils-mips-linux-gnu
+```
+
+## Install splat
+
+We'll install `splat` using `pip` and enable its `mips` dependencies:
+
+```sh
+python3 -m pip install -U splat64[mips]
+```
+
+## Create a config file from your ELF
+
+`splat` has a script that will generate a `yaml` file based in the ELF file.
+
+```sh
+python3 -m splat create_config SLUS_XXX.YY
+```
+
+This command generates a few files, from which the most important ones are the `SLUS_XXX.YY.rom` and the `SLUS_XXX.YY.yaml`.
+
+### The generated ROM
+
+The original ELF file contains the game code and a lot of extra metadata which we don't care about.
+
+To get rid of the extra metadata the `create_config` script generated a ROM that only contains the game code and data, and the generated `yaml` is used to split this ROM instead of splitting the original ELF, making the splitting and build process a lot more cleaner.
+
+To generate this ROM the `create_config` script uses `objcopy`. You can (and should) integrate this ROM generation step into your setup script / configure script. `create_config` tells you exactly what command it used to generate the ROM, which should look similar to the following:
+
+```sh
+mips-linux-gnu-objcopy -O binary --gap-fill=0x00 SLUS_XXX.YY SLUS_XXX.YY.rom
+```
+
+This approach has a few pros and cons. The biggest pro is being able to generate an ELF with proper metadata as part of your build system, making a lot easier to achieve shiftability eventually. Note only this is not enough for shiftability, other factors must be worked out, like symbol alignment, fake symbols, etc.
+
+### The generated `yaml`
+
+`create_config` generates a `yaml` file which describes how the ROM is structured, what parts are code, data, etc. It also includes configuration values for splat.
+
+Below is an example of what a generated yaml may look like:
+
+```yaml
+# name: Your game name here!
+sha1: 6da2d0a02aafe3bfba71ca8ba859174756ba3f5e
+options:
+  basename: SLUS_206.24
+  target_path: SLUS_206.24.rom
+  elf_path: build/SLUS_206.24.elf
+  base_path: .
+  platform: ps2
+  compiler: EEGCC
+
+  gp_value: 0x003A0EF0
+  ld_gp_expression: cod_SBSS_START + 0x7FF0
+
+  # asm_path: asm
+  # src_path: src
+  # build_path: build
+
+  ld_script_path: SLUS_206.24.ld
+  ld_dependencies: True
+  ld_wildcard_sections: True
+  ld_bss_contains_common: True
+
+  create_asm_dependencies: True
+
+  find_file_boundaries: False
+
+  o_as_suffix: True
+
+  symbol_addrs_path:
+    - symbol_addrs.txt
+  reloc_addrs_path:
+    - reloc_addrs.txt
+
+  # undefined_funcs_auto_path: undefined_funcs_auto.txt
+  # undefined_syms_auto_path: undefined_syms_auto.txt
+
+  extensions_path: tools/splat_ext
+
+  string_encoding: ASCII
+  data_string_encoding: ASCII
+  rodata_string_guesser_level: 2
+  data_string_guesser_level: 2
+
+  named_regs_for_c_funcs: False
+
+  section_order:
+    - .text
+    # - .vutext
+    - .data
+    - .rodata
+    - .gcc_except_table
+    - .sbss
+    - .bss
+
+  auto_link_sections:
+    - .data
+    - .rodata
+    - .gcc_except_table
+    - .sbss
+    - .bss
+
+segments:
+  - name: cod
+    type: code
+    start: 0x000000
+    vram: 0x00100000
+    bss_size: 0x6907C
+    subalign: null
+    subsegments:
+      - [0x000000, asm, cod/000000] # .text
+      - [0x3209C0, textbin, cod/3209C0] # .vutext
+      - [0x324680, data, cod/324680] # .data
+      - [0x350100, rodata, cod/350100] # .rodata
+      - [0x3B0780, gcc_except_table, cod/3B0780] # .gcc_except_table
+      - { type: sbss, vram: 0x004B0880, name: cod/004B0880 } # .sbss
+      - { type: bss, vram: 0x004B0F80, name: cod/004B0F80 } # .bss
+  - [0x3B0864]
+```
+
+This is a bare-bones configuration and there is a lot of work required to map out the different sections of the ROM.
+
+## Run splat with your configuration
+
+```sh
+python3 -m splat split SLUS_XXX.YY.yaml
+```
+
+The output will look something like this:
+
+```plain_text
+splat 0.36.2 (powered by spimdisasm 1.38.0)
+Loading symbols (symbol_addrs): 100%|█████████████████████████| 2/2 [00:00<00:00, 9868.95it/s]
+Scanning cod:   0%|                                                     | 0/1 [00:00<?, ?it/s]
+Rodata segment 'cod/350100' may belong to the text segment 'cod/000000'
+    Based on the usage from the function func_00102E48 to the symbol D_00450308
+Scanning cod: 100%|█████████████████████████████████████████████| 1/1 [00:26<00:00, 26.62s/it]
+Splitting cod: 100%|████████████████████████████████████████████| 1/1 [00:14<00:00, 14.77s/it]
+Linker script cod: 100%|███████████████████████████████████████| 1/1 [00:00<00:00, 447.54it/s]
+Split 3 MB (85.17%) in defined segments
+                 asm:     3 MB (84.76%) 1 split, 0 cached
+             textbin:    15 KB (0.40%) 1 split, 0 cached
+             unknown:      0 B (0.00%) from unknown bin files
+```
+
+It's up to you to figure out the layout of the ROM, finding proper file splits.
+
+## Next Steps
+
+The reassembly of the ROM is currently out of scope of this quickstart, as is switching out the `asm` segments for `c` or `cpp`.
+
+You can find a general workflow for using `splat` at [General Workflow](https://github.com/ethteck/splat/wiki/General-Workflow)
+
+Please feel free to improve this guide!

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -1,6 +1,7 @@
 # Quickstart
 
-> **Note**: This quickstart is written with N64 ROMs in mind, and the assumption that you are using Ubuntu 20.04 either natively, via WSL2 or via Docker.
+> [!NOTE]
+> This quickstart is written with N64 ROMs in mind, and the assumption that you are using Ubuntu 20.04 either natively, via WSL2 or via Docker.
 
 For the purposes of this quickstart, we will assume that we are going to split a game called `mygame` and we have the ROM in `.z64` format named `baserom.z64`.
 
@@ -19,7 +20,7 @@ Copy the `baserom.z64` file into the `mygame` directory inside your home directo
 Ensure you are have **Python 3.9** or higher installed:
 
 ```sh
-python3 --version
+$ python3 --version
 Python 3.9.10
 ```
 

--- a/src/splat/scripts/create_config.py
+++ b/src/splat/scripts/create_config.py
@@ -440,13 +440,15 @@ options:
 """
 
     header += "\n  section_order:\n"
-    for sect in elf.elf_section_names:
-        header += f"    - {sect}\n"
+    for (sect, is_valid) in elf.elf_section_names:
+        comment = "" if is_valid else "# "
+        header += f"    {comment}- {sect}\n"
 
     header += "\n  auto_link_sections:\n"
-    for sect in elf.elf_section_names:
+    for (sect, is_valid) in elf.elf_section_names:
+        comment = "" if is_valid else "# "
         if sect != ".text" and sect != ".vutext":
-            header += f"    - {sect}\n"
+            header += f"    {comment}- {sect}\n"
 
     segments = "\nsegments:"
     for seg in elf.segs:

--- a/src/splat/scripts/create_config.py
+++ b/src/splat/scripts/create_config.py
@@ -437,12 +437,12 @@ options:
 
     header += "\n  auto_link_sections:\n"
     for sect in elf.elf_section_names:
-        if sect != ".text":
+        if sect != ".text" and sect != ".vutext":
             header += f"    - {sect}\n"
 
-    segments = "\nsegments:\n"
+    segments = "\nsegments:"
     for seg in elf.segs:
-        segments += f"""\
+        segments += f"""
   - name: {seg.name}
     type: code
     start: 0x{seg.start:06X}
@@ -453,7 +453,7 @@ options:
 """
         for section in seg.sections:
             if section.is_nobits:
-                segments += f"      - {{ type: {section.splat_segment_type}, vram: 0x{section.vram:08X}, name: {seg.name}/{section.start:06X} }} # {section.name}\n"
+                segments += f"      - {{ type: {section.splat_segment_type}, vram: 0x{section.vram:08X}, name: {seg.name}/{section.vram:08X} }} # {section.name}\n"
             else:
                 segments += f"      - [0x{section.start:06X}, {section.splat_segment_type}, {seg.name}/{section.start:06X}] # {section.name}\n"
 

--- a/src/splat/scripts/create_config.py
+++ b/src/splat/scripts/create_config.py
@@ -32,7 +32,7 @@ def main(file_path: Path, objcopy: Optional[str]):
         return
 
     # Check for ELFs
-    if file_bytes[0:4] == b"\x7FELF":
+    if file_bytes[0:4] == b"\x7fELF":
         do_elf(file_path, file_bytes, objcopy)
         return
 

--- a/src/splat/scripts/create_config.py
+++ b/src/splat/scripts/create_config.py
@@ -396,10 +396,18 @@ options:
   base_path: .
   platform: ps2
   compiler: {elf.compiler}
+"""
 
-  # gp_value:
-  # ld_gp_expression:
+    if elf.gp is not None:
+        header += f"""
+  gp_value: 0x{elf.gp:08X}
+"""
+        if elf.ld_gp_expression is not None:
+            header += f"  ld_gp_expression: {elf.ld_gp_expression}\n"
+        else:
+            header += "  # ld_gp_expression:\n"
 
+    header += f"""
   # asm_path: asm
   # src_path: src
   # build_path: build

--- a/src/splat/scripts/create_config.py
+++ b/src/splat/scripts/create_config.py
@@ -1,15 +1,19 @@
 #! /usr/bin/env python3
 
 import argparse
-import sys
+import hashlib
 from pathlib import Path
+import subprocess
+import sys
+from typing import Optional
 
 from ..util.n64 import find_code_length, rominfo
 from ..util.psx import psxexeinfo
+from ..util.ps2 import ps2elfinfo
 from ..util import log, file_presets, conf
 
 
-def main(file_path: Path):
+def main(file_path: Path, objcopy: Optional[str]):
     if not file_path.exists():
         sys.exit(f"File {file_path} does not exist ({file_path.absolute()})")
     if file_path.is_dir():
@@ -25,6 +29,11 @@ def main(file_path: Path):
     # Check for PSX executable
     if file_bytes[0:8] == b"PS-X EXE":
         create_psx_config(file_path, file_bytes)
+        return
+
+    # Check for ELFs
+    if file_bytes[0:4] == b"\x7FELF":
+        do_elf(file_path, file_bytes, objcopy)
         return
 
     log.error(f"create_config does not support the file format of '{file_path}'")
@@ -360,15 +369,157 @@ segments:
     file_presets.write_all_files()
 
 
+def do_elf(elf_path: Path, elf_bytes: bytes, objcopy: Optional[str]):
+    elf = ps2elfinfo.Ps2Elf.get_info(elf_path, elf_bytes)
+    if elf is None:
+        log.error(f"Unsupported elf file '{elf_path}'")
+
+    basename = elf_path.name.replace(" ", "")
+    cleaned_basename = remove_invalid_path_characters(basename)
+
+    rom_name = Path(f"{cleaned_basename}.rom")
+    # Prefer the user objcopy
+    if objcopy is None:
+        objcopy = find_objcopy()
+    run_objcopy(objcopy, str(elf_path), str(rom_name))
+
+    sha1 = hashlib.sha1(rom_name.read_bytes()).hexdigest()
+
+    # TODO: gp_value and ld_gp_expression
+    header = f"""\
+# name: Your game name here!
+sha1: {sha1}
+options:
+  basename: {basename}
+  target_path: {rom_name}
+  elf_path: build/{cleaned_basename}.elf
+  base_path: .
+  platform: ps2
+  compiler: {elf.compiler}
+
+  # gp_value:
+  # ld_gp_expression:
+
+  # asm_path: asm
+  # src_path: src
+  # build_path: build
+
+  ld_script_path: {cleaned_basename}.ld
+  ld_dependencies: True
+  create_asm_dependencies: True
+
+  find_file_boundaries: False
+
+  o_as_suffix: True
+
+  symbol_addrs_path:
+    - symbol_addrs.txt
+  reloc_addrs_path:
+    - reloc_addrs.txt
+
+  # undefined_funcs_auto_path: undefined_funcs_auto.txt
+  # undefined_syms_auto_path: undefined_syms_auto.txt
+
+  extensions_path: tools/splat_ext
+
+  string_encoding: ASCII
+  data_string_encoding: ASCII
+  rodata_string_guesser_level: 2
+  data_string_guesser_level: 2
+
+  # mips_abi_gpr: numeric
+  # mips_abi_float_regs: numeric
+"""
+
+    header += "\n  section_order:\n"
+    for sect in elf.elf_section_names:
+        header += f"    - {sect}\n"
+
+    header += "\n  auto_link_sections:\n"
+    for sect in elf.elf_section_names:
+        if sect != ".text":
+            header += f"    - {sect}\n"
+
+    segments = "\nsegments:\n"
+    for seg in elf.segs:
+        segments += f"""\
+  - name: {seg.name}
+    type: code
+    start: 0x{seg.start:06X}
+    vram: 0x{seg.vram:08X}
+    bss_size: 0x{seg.bss_size:X}
+    subalign: null
+    subsegments:
+"""
+        for section in seg.sections:
+            if section.is_nobits:
+                segments += f"      - {{ type: {section.splat_segment_type}, vram: 0x{section.vram:08X}, name: {seg.name}/{section.start:06X} }} # {section.name}\n"
+            else:
+                segments += f"      - [0x{section.start:06X}, {section.splat_segment_type}, {seg.name}/{section.start:06X}] # {section.name}\n"
+
+    segments += f"""\
+  - [0x{elf.size:X}]
+"""
+
+    out_file = Path(f"{cleaned_basename}.yaml")
+    with out_file.open("w", newline="\n") as f:
+        print(f"Writing config to {out_file}")
+        f.write(header)
+        f.write(segments)
+
+    # `file_presets` requires an initialized `opts`.
+    # A simple way to do that is to simply load the yaml we just generated.
+    conf.load([out_file])
+    file_presets.write_all_files()
+
+    # TODO: symbol_addrs for entrypoint. Use _start
+    # TODO: linker script with ENTRY(_start);
+
+
+def find_objcopy() -> str:
+    # First we try to figure out if the user has objcopy on their pc, and under
+    # which name.
+    # We just try a bunch and hope for the best
+    options = [
+        "mips-linux-gnu-objcopy",
+        "mipsel-linux-gnu-objcopy",
+    ]
+
+    for name in options:
+        sub = subprocess.run([name, "--version"], capture_output=True)
+        if sub.returncode == 0:
+            return name
+
+    msg = "Unable to find objcopy.\nI tried the following list of names:\n"
+    for name in options:
+        msg += f"  - {name}\n"
+    msg += "\nTry to install one of those or use the `--objcopy` flag to pass the name to your own objcopy to me."
+    log.error(msg)
+
+
+def run_objcopy(objcopy_name: str, elf_path: str, rom: str):
+    cmd = [objcopy_name, "-O", "binary", "--gap-fill=0x00", elf_path, rom]
+    print("Running:", " ".join(cmd))
+    sub = subprocess.run(cmd)
+    if sub.returncode != 0:
+        log.error("Failed to run objcopy")
+
+
 def add_arguments_to_parser(parser: argparse.ArgumentParser):
     parser.add_argument(
         "file",
-        help="Path to a .z64/.n64 ROM or PSX executable",
+        help="Path to a .z64/.n64 ROM, PSX executable or PS2 ELF",
+        type=Path,
+    )
+    parser.add_argument(
+        "--objcopy",
+        help="Path to an user-provided objcopy program. Only used when processing ELF files",
+        type=str,
     )
 
 
 def process_arguments(args: argparse.Namespace):
-    main(Path(args.file))
+    main(args.file, args.objcopy)
 
 
 script_description = "Create a splat config from an N64 ROM or PSX executable."

--- a/src/splat/util/__init__.py
+++ b/src/splat/util/__init__.py
@@ -7,6 +7,7 @@ from . import n64 as n64
 from . import options as options
 from . import palettes as palettes
 from . import progress_bar as progress_bar
+from . import ps2 as ps2
 from . import psx as psx
 from . import relocs as relocs
 from . import statistics as statistics

--- a/src/splat/util/ps2/__init__.py
+++ b/src/splat/util/ps2/__init__.py
@@ -1,0 +1,1 @@
+from . import ps2elfinfo as ps2elfinfo

--- a/src/splat/util/ps2/ps2elfinfo.py
+++ b/src/splat/util/ps2/ps2elfinfo.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import dataclasses
 from pathlib import Path
 import spimdisasm
-from spimdisasm.elf32 import Elf32File, Elf32Constants, Elf32SectionHeaderFlag, Elf32ObjectFileType
+from spimdisasm.elf32 import (
+    Elf32File,
+    Elf32Constants,
+    Elf32SectionHeaderFlag,
+    Elf32ObjectFileType,
+)
 from typing import Optional
 
 from .. import log
@@ -23,8 +28,8 @@ ELF_SECTION_MAPPING: dict[str, str] = {
     ".lit8": "lit8",
     ".ctor": "ctor",
     ".vtables": "vtables",
-    ".vutext": "textbin", # No "proper" support yet
-    ".vudata": "databin", # No "proper" support yet
+    ".vutext": "textbin",  # No "proper" support yet
+    ".vudata": "databin",  # No "proper" support yet
 }
 
 # Section to not put into the elf_section_names list, because splat doesn't
@@ -127,7 +132,10 @@ class Ps2Elf:
             elif typ == Elf32Constants.Elf32SectionHeaderType.MIPS_REGINFO:
                 continue
             else:
-                log.write(f"Unknown section type '{typ}' ({name}) found in the elf", status="warn")
+                log.write(
+                    f"Unknown section type '{typ}' ({name}) found in the elf",
+                    status="warn",
+                )
                 return None
 
             if first_offset is None:
@@ -215,7 +223,6 @@ class Ps2Elf:
             gp,
             ld_gp_expression,
         )
-
 
 
 @dataclasses.dataclass

--- a/src/splat/util/ps2/ps2elfinfo.py
+++ b/src/splat/util/ps2/ps2elfinfo.py
@@ -55,7 +55,7 @@ class Ps2Elf:
     segs: list[FakeSegment]
     size: int
     compiler: str
-    elf_section_names: list[str]
+    elf_section_names: list[tuple[str, bool]]
     gp: Optional[int]
     ld_gp_expression: Optional[str]
 
@@ -89,7 +89,7 @@ class Ps2Elf:
         # TODO: check `.comment` section for any compiler info
         compiler = "EEGCC"
 
-        elf_section_names = []
+        elf_section_names: list[tuple[str, bool]] = []
 
         first_offset: Optional[int] = None
         rom_size = 0
@@ -164,8 +164,9 @@ class Ps2Elf:
                     # Whatever...
                     splat_segment_type = "rodata"
 
-            if name in ELF_SECTION_MAPPING and name not in ELF_SECTIONS_IGNORE:
-                elf_section_names.append(name)
+            if name.startswith("."):
+                valid_for_splat = name in ELF_SECTION_MAPPING and name not in ELF_SECTIONS_IGNORE and not do_new_segs
+                elf_section_names.append((name, valid_for_splat))
 
             new_section = ElfSection(
                 name,
@@ -189,18 +190,18 @@ class Ps2Elf:
         # hoping for the best.
         if len(elf_section_names) < 4:
             elf_section_names = [
-                ".text",
-                # ".vutext",
-                ".data",
-                # ".vudata",
-                ".rodata",
-                ".gcc_except_table",
-                ".lit8",
-                ".lit4",
-                ".sdata",
-                ".sbss",
-                ".bss",
-                # ".vubss",
+                (".text", True),
+                (".vutext", False),
+                (".data", True),
+                (".vudata", False),
+                (".rodata", True),
+                (".gcc_except_table", True),
+                (".lit8", True),
+                (".lit4", True),
+                (".sdata", True),
+                (".sbss", True),
+                (".bss", True),
+                (".vubss", False),
             ]
 
         # Fixup vram address of segments

--- a/src/splat/util/ps2/ps2elfinfo.py
+++ b/src/splat/util/ps2/ps2elfinfo.py
@@ -165,7 +165,11 @@ class Ps2Elf:
                     splat_segment_type = "rodata"
 
             if name.startswith("."):
-                valid_for_splat = name in ELF_SECTION_MAPPING and name not in ELF_SECTIONS_IGNORE and not do_new_segs
+                valid_for_splat = (
+                    name in ELF_SECTION_MAPPING
+                    and name not in ELF_SECTIONS_IGNORE
+                    and not do_new_segs
+                )
                 elf_section_names.append((name, valid_for_splat))
 
             new_section = ElfSection(

--- a/src/splat/util/ps2/ps2elfinfo.py
+++ b/src/splat/util/ps2/ps2elfinfo.py
@@ -1,0 +1,192 @@
+#! /usr/bin/env python3
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+import spimdisasm
+from spimdisasm.elf32 import Elf32File, Elf32Constants, Elf32SectionHeaderFlag, Elf32ObjectFileType
+from typing import Optional
+
+from .. import log
+
+
+ELF_SECTION_MAPPING: dict[str, str] = {
+    ".text": "asm",
+    ".data": "data",
+    ".rodata": "rodata",
+    ".bss": "bss",
+    ".sbss": "sbss",
+    ".gcc_except_table": "gcc_except_table",
+    ".lit4": "lit4",
+    ".lit8": "lit8",
+    ".ctor": "ctor",
+    ".vtables": "vtables",
+    ".vutext": "textbin", # No "proper" support yet
+    ".vudata": "databin", # No "proper" support yet
+}
+
+
+@dataclasses.dataclass
+class Ps2Elf:
+    entrypoint: int
+    segs: list[FakeSegment]
+    size: int
+    compiler: str
+    elf_section_names: list[str]
+    # gp: Optional[int] # TODO
+
+    @staticmethod
+    def get_info(elf_path: Path, elf_bytes: bytes) -> Optional[Ps2Elf]:
+        # Avoid spimdisasm from complaining about unknown sections.
+        spimdisasm.common.GlobalConfig.QUIET = True
+
+        elf = Elf32File(elf_bytes)
+        if elf.header.type != Elf32ObjectFileType.EXEC.value:
+            log.write("Elf file is not an EXEC type.", status="warn")
+            return None
+        if elf.header.machine != 8:
+            # 8 corresponds to EM_MIPS
+            # We only care about mips binaries.
+            log.write("Elf file is not a MIPS binary.", status="warn")
+            return None
+        if Elf32Constants.Elf32HeaderFlag._5900 not in elf.elfFlags:
+            log.write("Missing 5900 flag", status="warn")
+            return None
+
+        entrypoint = elf.header.entry
+        start = 0
+        segs = [FakeSegment("cod", 0, start, [])]
+
+        # TODO: check `.comment` section for any compiler info
+        compiler = "EEGCC"
+
+        elf_section_names = []
+
+        previous_type = Elf32Constants.Elf32SectionHeaderType.PROGBITS
+        do_new_segs = False
+        for section in elf.sectionHeaders:
+            if section.size == 0:
+                continue
+
+            name = elf.shstrtab[section.name]
+            if name == ".mwcats":
+                compiler = "MWCCPS2"
+                continue
+
+            flags, _unknown_flags = Elf32SectionHeaderFlag.parseFlags(section.flags)
+            if Elf32SectionHeaderFlag.ALLOC not in flags:
+                continue
+
+            typ = Elf32Constants.Elf32SectionHeaderType.fromValue(section.type)
+            is_nobits = typ == Elf32Constants.Elf32SectionHeaderType.NOBITS
+            if typ == Elf32Constants.Elf32SectionHeaderType.PROGBITS:
+                if previous_type == Elf32Constants.Elf32SectionHeaderType.NOBITS:
+                    do_new_segs = True
+                pass
+            elif typ == Elf32Constants.Elf32SectionHeaderType.NOBITS:
+                pass
+            elif typ == Elf32Constants.Elf32SectionHeaderType.MIPS_REGINFO:
+                continue
+            else:
+                log.write(f"Unknown section type '{typ}' ({name}) found in the elf", status="warn")
+                return None
+
+            start = align_up(start, section.addralign)
+            size = align_up(section.size, section.addralign)
+
+            if do_new_segs:
+                segs.append(FakeSegment(name, 0, start, []))
+
+            splat_segment_type = ELF_SECTION_MAPPING.get(name)
+            if splat_segment_type is None:
+                # Let's infer based on the section's flags
+                if is_nobits:
+                    splat_segment_type = "bss"
+                elif Elf32SectionHeaderFlag.EXECINSTR in flags:
+                    splat_segment_type = "asm"
+                elif Elf32SectionHeaderFlag.WRITE in flags:
+                    splat_segment_type = "data"
+                else:
+                    # Whatever...
+                    splat_segment_type = "rodata"
+
+            if name.startswith("."):
+                elf_section_names.append(name)
+
+            new_section = ElfSection(
+                name,
+                splat_segment_type,
+                section.addr,
+                start,
+                size,
+                is_nobits,
+            )
+            segs[-1].sections.append(new_section)
+            if is_nobits:
+                segs[-1].bss_size += size
+            else:
+                start += size
+
+            print(name, section.addralign)
+
+            previous_type = typ
+
+        # There are some games where they just squashed most sections into a
+        # single one, making the elf_section_names list pretty useless.
+        # We try to detect this and provide a default list if that's the case,
+        # hoping for the best.
+        if len(elf_section_names) < 4:
+            elf_section_names = [
+                ".text",
+                # ".vutext",
+                ".data",
+                # ".vudata",
+                ".rodata",
+                ".gcc_except_table",
+                ".lit8",
+                ".lit4",
+                ".sdata",
+                ".sbss",
+                ".bss",
+                # ".vubss",
+            ]
+
+        # Fixup vram address of segments
+        for seg in segs:
+            seg.vram = seg.sections[0].vram
+
+        return Ps2Elf(
+            entrypoint,
+            segs,
+            start,
+            compiler,
+            elf_section_names,
+        )
+
+
+
+@dataclasses.dataclass
+class FakeSegment:
+    name: str
+    vram: int
+    start: int
+    sections: list[ElfSection]
+    bss_size: int = 0
+
+
+@dataclasses.dataclass
+class ElfSection:
+    name: str
+    splat_segment_type: str
+    vram: int
+    start: int
+    size: int
+    is_nobits: bool
+
+
+def align_up(number: int, align: int) -> int:
+    mod = number % align
+    if mod == 0:
+        return number
+    return number + (align - mod)


### PR DESCRIPTION
Adds support for PS2 ELFs in `create_config` by using the "fake rom" approach.
This avoid issues in the long run generating elf within an elf in the build system, but adds `objcopy` as a dependency of `create_config` for PS2. Since we can't know what `objcopy` flavour the user may want to use then `create_config` will try to figure out which one the user has from a list. The user can also provide their own `objcopy` by passing a flag.

The generated yaml is generated from the elf and it includes info like each section from the game and automatically fill `section_order` and similar variables, `gp` value if available and a `ld_gp_expression` setting when possible, inferred compiler and tweaked default settings for ps2.
The compiler inferring machinery is pretty weak. Currently it assumes `EEGCC` unless there's a `.mwcats` section present in the ELF. I think this should be good enough as an starting point, and we can improve this in the future.

Since splat doesn't have built-in support for `vutext`, `vudata`, etc, those kind of sections will be listed as `incbin`s instead.

I also wrote some docs in a separate Quickstart page. Hopefully everything is clear enough.

I'm not sure how to bump the splat version. Should I do +`0.1.0` or +`0.0.1`?
