### PR TITLE
Fix `gfx` segments sometimes not picking up properly the corresponding typed reference.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # splat Release Notes
 
+* Fix `gfx` segments sometimes not picking up properly the corresponding typed reference.
+
 ### 0.36.3
 
 * Fix not generating nonmatching `.s` files for quoted symbols.

--- a/src/splat/segtypes/segment.py
+++ b/src/splat/segtypes/segment.py
@@ -811,8 +811,7 @@ class Segment:
         items = [
             i
             for i in items
-            if i.segment is None
-            or Segment.visible_ram(self, i.segment)
+            if (i.segment is None or Segment.visible_ram(self, i.segment))
             and (type == i.type)
         ]
 


### PR DESCRIPTION
A silly bug caused by `and` having a higher operator precedence than `or`.
(https://docs.python.org/3/reference/expressions.html#operator-precedence)