### PR TITLE
Fix `make_full_disasm_for_code` not extracting data-only TUs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # splat Release Notes
 
+### 0.37.1
+
+* Fix `make_full_disasm_for_code` not extracting data-only TUs.
+
 ### 0.37.0
 
 * Add define check to allow using `macro.inc` instead of `labels.inc` in `include_asm.h`.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The brackets corresponds to the optional dependencies to install while installin
 If you use a `requirements.txt` file in your repository, then you can add this library with the following line:
 
 ```txt
-splat64[mips]>=0.37.0,<1.0.0
+splat64[mips]>=0.37.1,<1.0.0
 ```
 
 ### Optional dependencies

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -848,6 +848,16 @@ Emit a full `.s` file for each `c`/`cpp` segment containing disassembly of .text
 
 Can be used to generate "target" or "expected" objects for asm diffing.
 
+To generate `.s` files for data-only TUs (or rodata/bss only, or any other combination that doesn't have a text section) a dummy `c` or `cpp` section with the same name as the data section must be defined in the yaml with an start value of `auto` instead of a number. For example:
+
+```yaml
+      - [auto, c, boot/rom_offsets]
+
+      # -- Other c or data subsegments --
+
+      - [0x00F340, .data, boot/rom_offsets]
+```
+
 ### global_vram_start and global_vram_end
 
 Allow specifying that the global memory range may be larger than what was automatically detected.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.37.0"
+version = "0.37.1"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -1,7 +1,7 @@
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version__ = "0.37.0"
+__version__ = "0.37.1"
 __author__ = "ethteck"
 
 from . import util as util

--- a/src/splat/segtypes/common/c.py
+++ b/src/splat/segtypes/common/c.py
@@ -152,6 +152,8 @@ class CommonSegC(CommonSegCodeSubsegment):
 
     def split(self, rom_bytes: bytes):
         if self.is_auto_segment:
+            if options.opts.make_full_disasm_for_code:
+                self.split_as_asmtu_file(self.asm_out_path())
             return
 
         if self.rom_start != self.rom_end:

--- a/src/splat/util/file_presets.py
+++ b/src/splat/util/file_presets.py
@@ -42,9 +42,6 @@ def write_include_asm_h():
         return
 
     directory = options.opts.generated_asm_macros_directory.as_posix()
-    print()
-    print(directory)
-    print()
 
     if options.opts.include_asm_macro_style == "maspsx_hack":
         include_asm_macro = """\


### PR DESCRIPTION
Allows to disassemble data-only sections by declaring an `auto` c subsegment with the same name.

Fixes #507