### PR TITLE
Fix data-only splits missing the initial `macro.inc` include.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # splat Release Notes
 
+### 0.39.1
+
+* Fix data-only splits missing the initial `macro.inc` include.
+
 ### 0.39.0
 
 * New `o` segment allowing for a more granular way to include library objects.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The brackets corresponds to the optional dependencies to install while installin
 If you use a `requirements.txt` file in your repository, then you can add this library with the following line:
 
 ```txt
-splat64[mips]>=0.39.0,<1.0.0
+splat64[mips]>=0.39.1,<1.0.0
 ```
 
 ### Optional dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.39.0"
+version = "0.39.1"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -1,7 +1,7 @@
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version__ = "0.39.0"
+__version__ = "0.39.1"
 __author__ = "ethteck"
 
 from . import util as util

--- a/src/splat/segtypes/common/codesubsegment.py
+++ b/src/splat/segtypes/common/codesubsegment.py
@@ -258,14 +258,15 @@ class CommonSegCodeSubsegment(Segment):
         self.print_file_boundaries()
 
         with open(out_path, "w", newline="\n") as f:
+            for line in self.get_asm_file_header():
+                f.write(line + "\n")
+
             # self.spim_section would be None if the current section was
             # declared `auto` in the yaml.
             # This can be useful when there are TUs with only data/rodata/bss/etc
             # sections but not text section.
             if self.spim_section is not None:
                 # Write `.text` contents
-                for line in self.get_asm_file_header():
-                    f.write(line + "\n")
                 f.write(self.spim_section.disassemble())
 
             # Disassemble the siblings to this file by respecting the `section_order`


### PR DESCRIPTION
Fixes #528

Fixes an oversight introduced in version [0.37.1](https://github.com/ethteck/splat/releases/tag/0.37.1) 
Issue introduced by both #508 and #509 

Now the corresponding asm headers are emitted in those data only splits when using both `make_full_disasm_for_code` and `disassemble_all`.
