### PR TITLE
Allow `bss_size` for bss subsegments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # splat Release Notes
 
+### 0.41.0
+
+* Add `bss_size` attribute for `bss` subsegments.
+  * Allows to specify a size for bss subsegments when the size for the subsegment can't be infered.
+  * splat may be unable to infer the size when the bss subsegment is followed by a segment that doesn't define a vram address, like `lib`, so this option is provided as a fallback.
+  * `bss_size` for `bss` segments can only be used if the size can't be infered. It is a hard error to define one when splat can infer the size.
+
 ### 0.40.1
 
 * Always write the link dependency file.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The brackets corresponds to the optional dependencies to install while installin
 If you use a `requirements.txt` file in your repository, then you can add this library with the following line:
 
 ```txt
-splat64[mips]>=0.40.1,<1.0.0
+splat64[mips]>=0.41.0,<1.0.0
 ```
 
 ### Optional dependencies

--- a/docs/Segments.md
+++ b/docs/Segments.md
@@ -245,6 +245,10 @@ The `.rdata` segment behaves the same as the `.rodata` segment but supports roda
 
 Note that the `bss_size` option needs to be set at segment level for `bss` segments to work correctly.
 
+It is possible to specify a `bss_size` for a given `bss` subsegment only if it is impossible for splat to determine the size of the bss subsegment.
+This may happen if a `bss` subsegment is followed by a subsegment that doesn't have a vram address.
+It is not possible to specify a `bss_size` for a specific `bss` subsegment if splat can infer the size.
+
 **Example:**
 
 ```yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "splat64"
 # Should be synced with src/splat/__init__.py
-version = "0.40.1"
+version = "0.41.0"
 description = "A binary splitting tool to assist with decompilation and modding projects"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/splat/__init__.py
+++ b/src/splat/__init__.py
@@ -1,7 +1,7 @@
 __package_name__ = __name__
 
 # Should be synced with pyproject.toml
-__version__ = "0.40.1"
+__version__ = "0.41.0"
 __author__ = "ethteck"
 
 from . import util as util

--- a/src/splat/segtypes/common/bss.py
+++ b/src/splat/segtypes/common/bss.py
@@ -25,7 +25,7 @@ class CommonSegBss(CommonSegData):
         if bss_size is not None:
             if parsed_bss_size is not None:
                 log.error(
-                    f"Error: Passing bss_size attribute to bss section {self.name} (0x{vram_start:08X}) is not allowed when the size of the bss section can be inferred (was inferred to 0x{bss_size:X}).\n"""
+                    f"Error: Passing bss_size attribute to bss section {self.name} (0x{vram_start:08X}) is not allowed when the size of the bss section can be inferred (was inferred to 0x{bss_size:X}).\n"
                     "  Setting this attribute is only allowed when the bss size can't be inferred."
                 )
             self.bss_size = bss_size

--- a/src/splat/segtypes/common/bss.py
+++ b/src/splat/segtypes/common/bss.py
@@ -93,14 +93,12 @@ class CommonSegBss(CommonSegData):
                 f"Segment '{self.name}' (type '{self.type}') requires a vram address. Got '{self.vram_start}'"
             )
 
-        # Supposedly logic error, not user error
         if self.bss_size is None:
             log.error(
                 f"Unable to infer the size for segment '{self.name}' (type '{self.type}', vram 0x{self.vram_start:08X}).\n"
                 "  This may happen when this segment is followed by a segment that doesn't use a vram address.\n"
                 "  HINT: Try setting a vram address to the next segment in the yaml or set `bss_size=0xXXXX` for this segment."
             )
-
         bss_end = self.vram_start + self.bss_size
 
         self.spim_section = make_bss_section(

--- a/src/splat/segtypes/common/bss.py
+++ b/src/splat/segtypes/common/bss.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Union
 
 from ...util import options, symbols, log
 
@@ -10,6 +10,39 @@ from ...disassembler.disassembler_section import DisassemblerSection, make_bss_s
 
 
 class CommonSegBss(CommonSegData):
+    def __init__(
+        self,
+        rom_start: Optional[int],
+        rom_end: Optional[int],
+        type: str,
+        name: str,
+        vram_start: Optional[int],
+        args: list,
+        yaml: Union[dict, list],
+        bss_size: Optional[int] = None,
+    ):
+        parsed_bss_size = self.parse_bss_size(yaml)
+        if bss_size is not None:
+            if parsed_bss_size is not None:
+                log.error(
+                    f"Error: Passing bss_size attribute to bss section {self.name} (0x{vram_start:08X}) is not allowed when the size of the bss section can be inferred (was inferred to 0x{bss_size:X}).\n"""
+                    "  Setting this attribute is only allowed when the bss size can't be inferred."
+                )
+            self.bss_size = bss_size
+        else:
+            self.bss_size = parsed_bss_size
+
+        super().__init__(
+            rom_start,
+            rom_end,
+            type,
+            name,
+            vram_start,
+            args=args,
+            yaml=yaml,
+            bss_size=self.bss_size,
+        )
+
     def get_linker_section(self) -> str:
         return ".bss"
 
@@ -61,7 +94,13 @@ class CommonSegBss(CommonSegData):
             )
 
         # Supposedly logic error, not user error
-        assert isinstance(self.bss_size, int), f"{self.name} {self.bss_size}"
+        if self.bss_size is None:
+            log.error(
+                f"Unable to infer the size for segment '{self.name}' (type '{self.type}', vram 0x{self.vram_start:08X}).\n"
+                "  This may happen when this segment is followed by a segment that doesn't use a vram address.\n"
+                "  HINT: Try setting a vram address to the next segment in the yaml or set `bss_size=0xXXXX` for this segment."
+            )
+
         bss_end = self.vram_start + self.bss_size
 
         self.spim_section = make_bss_section(


### PR DESCRIPTION
I was trying to run splat on a very outdated project and got an error here, because splat can't figure out the size for this bss section.

```yaml
      - { start: 0x50E0, type: bss, vram: 0x800044E0 }
      - [0x50E0, lib, libultra_rom_boot, initialize, .bss]
```

splat tries to calculate the vram address for a segment by subtracting its vram to the vram of the next segment.
In this case, the next segment doesn't have a vram address, so splat choked with an assert.

With this PR it is possible to specify a bss_size for this specific bss subsegment, getting rid of the issue.

```yaml
      - { start: 0x50E0, type: bss, vram: 0x800044E0, bss_size: 0x2A70 }
      - [0x50E0, lib, libultra_rom_boot, initialize, .bss]
```

This should be used as a last resort tho, because this attribute can get outdated pretty quickly when doing more file splits, so I added a check to ensure is not possible to use this if the size can actually be inferred.
