### PR TITLE
fix follows_classes chains

### DIFF
--- a/src/splat/scripts/split.py
+++ b/src/splat/scripts/split.py
@@ -366,7 +366,9 @@ def write_linker_script(all_segments: List[Segment]) -> LinkerWriter:
     vram_classes_to_search = set(vram_class_dependencies.keys())
 
     max_vram_end_insertion_points: Dict[Segment, List[Tuple[str, List[Segment]]]] = {}
-    for seg in reversed(all_segments):
+    # Emit class start symbols before the first segment in each class so every
+    # member of the class references the same symbol assignment.
+    for seg in all_segments:
         if seg.vram_class in vram_classes_to_search:
             assert seg.vram_class.vram_symbol is not None
             if seg not in max_vram_end_insertion_points:


### PR DESCRIPTION
class start symbols for follows_classes were emitted at the last member of a class, leaving earlier members with forward references to an unassigned class symbol. when chained together, this broke ld and invalid overlapping ranges were being assigned (specifically in papermario-dx). this PR changes the order in which the class start symbols is emitted to come before the first class member, which results in a valid linker script.