### PR TITLE
Experiment: Try to make crunch64 not mandatory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,15 @@ dependencies = [
 
 [project.optional-dependencies]
 mips = [
-    "splat64[mips-min,compression]",
+    "splat64[mips-min,assets-n64,compression]",
 ]
 
 mips-min = [
     "spimdisasm>=1.42.1,<2.0.0", # This value should be keep in sync with the version listed on disassembler/spimdisasm_disassembler.py
     "rabbitizer>=1.12.0,<2.0.0",
+]
+assets-n64 = [
+    "splat64[mips-min]",
     "pygfxd>=1.0.5",
     "n64img>=0.3.3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,20 @@ dependencies = [
 
 [project.optional-dependencies]
 mips = [
+    "splat64[mips-min,mips-compression]",
+]
+
+mips-min = [
     "spimdisasm>=1.42.1,<2.0.0", # This value should be keep in sync with the version listed on disassembler/spimdisasm_disassembler.py
     "rabbitizer>=1.12.0,<2.0.0",
     "pygfxd>=1.0.5",
     "n64img>=0.3.3",
+]
+mips-compression = [
+    "splat64[mips-min]",
     "crunch64>=0.5.1,<1.0.0",
 ]
+
 dev = [
     "splat64[mips]",
     "ruff",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 
 [project.optional-dependencies]
 mips = [
-    "splat64[mips-min,mips-compression]",
+    "splat64[mips-min,compression]",
 ]
 
 mips-min = [
@@ -29,7 +29,7 @@ mips-min = [
     "pygfxd>=1.0.5",
     "n64img>=0.3.3",
 ]
-mips-compression = [
+compression = [
     "splat64[mips-min]",
     "crunch64>=0.5.1,<1.0.0",
 ]

--- a/src/splat/segtypes/n64/__init__.py
+++ b/src/splat/segtypes/n64/__init__.py
@@ -20,7 +20,7 @@ from . import vtx as vtx
 
 # Segments that require optional dependencies
 try:
-    # mips-compression
+    # compression
     from . import mio0 as mio0
     from . import yay0 as yay0
 except ImportError:

--- a/src/splat/segtypes/n64/__init__.py
+++ b/src/splat/segtypes/n64/__init__.py
@@ -12,10 +12,16 @@ from . import ia4 as ia4
 from . import ia8 as ia8
 from . import img as img
 from . import ipl3 as ipl3
-from . import mio0 as mio0
 from . import palette as palette
 from . import rgba16 as rgba16
 from . import rgba32 as rgba32
 from . import rsp as rsp
 from . import vtx as vtx
-from . import yay0 as yay0
+
+# Segments that require optional dependencies
+try:
+    # mips-compression
+    from . import mio0 as mio0
+    from . import yay0 as yay0
+except ImportError:
+    pass

--- a/src/splat/segtypes/n64/__init__.py
+++ b/src/splat/segtypes/n64/__init__.py
@@ -1,26 +1,37 @@
-from . import ci as ci
-from . import ci4 as ci4
-from . import ci8 as ci8
 from . import decompressor as decompressor
-from . import gfx as gfx
 from . import header as header
-from . import i1 as i1
-from . import i4 as i4
-from . import i8 as i8
-from . import ia16 as ia16
-from . import ia4 as ia4
-from . import ia8 as ia8
-from . import img as img
 from . import ipl3 as ipl3
 from . import palette as palette
-from . import rgba16 as rgba16
-from . import rgba32 as rgba32
 from . import rsp as rsp
 from . import vtx as vtx
 
 # Segments that require optional dependencies
+
+# assets-n64 (pygfxd)
 try:
-    # compression
+    from . import gfx as gfx
+except ImportError:
+    pass
+
+# assets-n64 (n64img)
+try:
+    from . import ci as ci
+    from . import ci4 as ci4
+    from . import ci8 as ci8
+    from . import i1 as i1
+    from . import i4 as i4
+    from . import i8 as i8
+    from . import ia16 as ia16
+    from . import ia4 as ia4
+    from . import ia8 as ia8
+    from . import img as img
+    from . import rgba16 as rgba16
+    from . import rgba32 as rgba32
+except ImportError:
+    pass
+
+# compression (crunch64)
+try:
     from . import mio0 as mio0
     from . import yay0 as yay0
 except ImportError:

--- a/src/splat/segtypes/segment.py
+++ b/src/splat/segtypes/segment.py
@@ -97,8 +97,8 @@ def empty_statistics() -> SegmentStatistics:
 
 
 _segments_from_optional_dependencies: dict[str, str] = {
-    "yay0": "mips-compression",
-    "mio0": "mips-compression",
+    "yay0": "compression",
+    "mio0": "compression",
 }
 
 

--- a/src/splat/segtypes/segment.py
+++ b/src/splat/segtypes/segment.py
@@ -96,11 +96,17 @@ def empty_statistics() -> SegmentStatistics:
     return collections.defaultdict(lambda: SegmentStatisticsInfo(size=0, count=0))
 
 
+_segments_from_optional_dependencies: dict[str, str] = {
+    "yay0": "mips-compression",
+    "mio0": "mips-compression",
+}
+
+
 class Segment:
     require_unique_name = True
 
     @staticmethod
-    def get_class_for_type(seg_type) -> Type["Segment"]:
+    def get_class_for_type(seg_type: str) -> Type["Segment"]:
         # so .data loads SegData, for example
         seg_type = seg_type.removeprefix(".")
 
@@ -115,14 +121,21 @@ class Segment:
                 segment_class = Segment.get_extension_segment_class(seg_type)
 
         if segment_class is None:
+            dependency_group = _segments_from_optional_dependencies.get(seg_type)
+            if dependency_group is not None:
+                log.error(
+                    f"Could not load segment type '{seg_type}'.\n"
+                    f"This segment is available by installing the optional dependency group `splat64[{dependency_group}]`"
+                )
             log.error(
-                f"could not load segment type '{seg_type}'\n(hint: confirm your extension directory is configured correctly)"
+                f"Could not load segment type '{seg_type}'\n"
+                "(hint: confirm your extension directory is configured correctly)"
             )
 
         return segment_class
 
     @staticmethod
-    def get_base_segment_class(seg_type):
+    def get_base_segment_class(seg_type: str) -> Optional[Type["Segment"]]:
         platform = options.opts.platform
         is_platform_seg = False
 
@@ -144,7 +157,7 @@ class Segment:
         return getattr(segmodule, f"{seg_prefix}Seg{seg_type.capitalize()}")
 
     @staticmethod
-    def get_extension_segment_class(seg_type):
+    def get_extension_segment_class(seg_type: str) -> Optional[Type["Segment"]]:
         platform = options.opts.platform
 
         ext_path = options.opts.extensions_path
@@ -167,7 +180,8 @@ class Segment:
             return None
 
         return getattr(
-            ext_mod, f"{platform.upper()}Seg{seg_type[0].upper()}{seg_type[1:]}"
+            ext_mod,
+            f"{platform.upper()}Seg{seg_type[0].upper()}{seg_type[1:]}",
         )
 
     @staticmethod

--- a/src/splat/segtypes/segment.py
+++ b/src/splat/segtypes/segment.py
@@ -96,9 +96,26 @@ def empty_statistics() -> SegmentStatistics:
     return collections.defaultdict(lambda: SegmentStatisticsInfo(size=0, count=0))
 
 
+# Mapping for segments that are enabled only when the corresponding dependency
+# is available at runtime.
+# The value corresponds to the dependency group listed on the pyproject.toml
+# file installs the required Python dependencies for the given segment.
 _segments_from_optional_dependencies: dict[str, str] = {
     "yay0": "compression",
     "mio0": "compression",
+    "gfx": "assets-n64",
+    "ci": "assets-n64",
+    "ci4": "assets-n64",
+    "ci8": "assets-n64",
+    "i1": "assets-n64",
+    "i4": "assets-n64",
+    "i8": "assets-n64",
+    "ia16": "assets-n64",
+    "ia4": "assets-n64",
+    "ia8": "assets-n64",
+    "img": "assets-n64",
+    "rgba16": "assets-n64",
+    "rgba32": "assets-n64",
 }
 
 


### PR DESCRIPTION
WIP for issue https://github.com/ethteck/splat/issues/331

The current state is an experiment. Looking for testing and feedback

With this branch you could avoid installing crunch64 and use everything else without much issue.
For this you would need to install `[mips-min]` instead of `[mips]` dependency group.

To test this branch, either:
- Checkout with git and do `pip install .[mips-min]` on a fresh venv.
- Directly with pip `pip uninstall splat64 -y && pip install git+https://github.com/AngheloAlf/splat.git@optional-dependencies[mips-min]` on a fresh venv.

A fresh venv is needed to ensure you don't have crunch64 from a previous installation.

If splat detects you want to use either `mio0` or `yay0` then it suggest you to install `splat64[compression]` to get them, since they aren't available here, I think. I haven't tried this tho, so would be nice if somebody tries it out first. `splat64[compression]` implies both `splat64[compression,mips-min]`

The usual `splat64[mips]` group still installs `crunch64` to avoid breaking current setups.

